### PR TITLE
Use simplemma instead of pycld3 for language detection

### DIFF
--- a/misc/export_tsv_annif.py
+++ b/misc/export_tsv_annif.py
@@ -1,7 +1,7 @@
 import sys
 
 import orjson
-import cld3
+from simplemma.langdetect import lang_detector
 
 from pipeline.storage import get_connection, dict_factory
 from pipeline.publication import Publication
@@ -58,11 +58,10 @@ def dump_tsv(target_language="en", number_of_records=10000, min_level=1, max_lev
 
                 # Remove summary if summary not in target language. We check all summaries
                 # (even the language-tagged ones) because we don't trust input.
-                language_prediction_summary = cld3.get_language(summary)
+                predicted_lang, lang_score = lang_detector(summary, lang=("sv", "en"))[0]
                 if (
-                    not language_prediction_summary
-                    or language_prediction_summary.language != target_language
-                    or not language_prediction_summary.is_reliable
+                    predicted_lang != target_language
+                    or score < 0.5:
                 ):
                     summary = ""
 

--- a/pipeline/publication.py
+++ b/pipeline/publication.py
@@ -5,7 +5,7 @@ import datetime
 from dateutil.parser import parse as parse_date
 from html import unescape
 
-import cld3
+from simplemma.langdetect import lang_detector
 from bs4 import BeautifulSoup
 from unidecode import unidecode
 
@@ -939,15 +939,15 @@ class Publication:
                     "label": new_summary_label
                 }
                 # Now try to figure out the language
-                language_prediction = cld3.get_language(new_summary_label)
-                if language_prediction and language_prediction.is_reliable:
-                    if language_prediction.language == "en":
+                predicted_lang, lang_score = lang_detector(new_summary_label, lang=("sv", "en"))[0]
+                if predicted_lang in ["sv", "en"] and lang_score >= 0.5:
+                    if predicted_lang == "en":
                         new_summary["language"] = {
                             "@type": "Language",
                             "@id": "https://id.kb.se/language/eng",
                             "code": "eng"
                         }
-                    elif language_prediction.language == "sv":
+                    elif predicted_lang == "sv":
                         new_summary["language"] = {
                             "@type": "Language",
                             "@id": "https://id.kb.se/language/swe",

--- a/pipeline/util.py
+++ b/pipeline/util.py
@@ -5,7 +5,7 @@ from jsonpath_rw import parse
 import re
 import Levenshtein
 import hashlib
-import cld3
+from simplemma.langdetect import lang_detector
 from unidecode import unidecode
 from requests.packages.urllib3.util.retry import Retry
 from random import random
@@ -551,8 +551,8 @@ def get_title_by_language(publication, language):
         sub_title = t.get("subtitle", "").strip()
         if sub_title:
             whole_title = f"{whole_title} {sub_title}"
-        language_prediction_title = cld3.get_language(whole_title)
-        if not language_prediction_title or language_prediction_title.language != language or not language_prediction_title.is_reliable:
+        predicted_lang, lang_score = lang_detector(whole_title, lang=("sv", "en"))[0]
+        if predicted_lang != language or lang_score < 0.5:
             continue
         title = whole_title
         break
@@ -574,8 +574,8 @@ def get_summary_by_language(publication, language):
 
     # Remove summary if summary not in target language. We check all summaries
     # (even the language-tagged ones) because we don't trust input.
-    language_prediction_summary = cld3.get_language(summary)
-    if not language_prediction_summary or language_prediction_summary.language != language or not language_prediction_summary.is_reliable:
+    predicted_lang, lang_score = lang_detector(summary, lang=("sv", "en"))[0]
+    if predicted_lang != language or lang_score < 0.5:
         summary = ""
 
     return summary

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,6 @@ python-Levenshtein==0.12.1
 aenum==3.1.11
 pathvalidate==2.5.2
 flexmock==0.11.3
-pycld3==0.22
 beautifulsoup4==4.11.1
 Unidecode==1.3.6
+simplemma==0.9.1

--- a/service/swepub.py
+++ b/service/swepub.py
@@ -27,7 +27,7 @@ from pypika.terms import BasicCriterion
 from pypika import functions as fn
 from collections import Counter
 from tempfile import NamedTemporaryFile
-import cld3
+from simplemma.langdetect import lang_detector
 
 from service.utils import bibliometrics
 from service.utils.common import *
@@ -417,8 +417,8 @@ def classify():
 
     annif_input = f"{title} {abstract} {keywords}"
 
-    language_prediction = cld3.get_language(annif_input) or ""
-    if language_prediction.language == "sv":
+    predicted_lang, lang_score = lang_detector(annif_input, lang=("sv", "en"))[0]
+    if predicted_lang == "sv":
         annif_url = ANNIF_SV_URL
     else:
         annif_url = ANNIF_EN_URL


### PR DESCRIPTION
For language detection, Annif switched from pycld3 to Simplemma. pycld3 has caused various dependency issues in both Linux and Mac for different people so let's follow suit (Simplemma is "written in pure Python with no dependencies").