### PR TITLE
Additional ways to express originInfo

### DIFF
--- a/misc/mods_to_json.py
+++ b/misc/mods_to_json.py
@@ -1,5 +1,5 @@
 import json
-from os import path, sys
+from os import sys
 from pathlib import Path
 import re
 
@@ -7,15 +7,14 @@ from flask import jsonify
 
 from pipeline.convert import ModsParser
 
-FILE_PATH = path.dirname(path.abspath(__file__))
-XSLT = Path(f"{FILE_PATH}/../resources/mods_to_xjsonld.xsl").read_text()
 
 if __name__ == "__main__":
-    if len(sys.argv) == 1:
-        print(f"Usage: in swepub-redux: python3 -m misc.mods_to_json <path-record-in-MODS-xml>")
+    if len(sys.argv) < 3:
+        print(f"Usage: in swepub-redux: python3 -m misc.mods_to_json <path-to-xsl> <path-record-in-MODS-xml>")
         sys.exit(1)
 
-    mods = Path(sys.argv[1]).read_text()
+    xslt = Path(sys.argv[1]).read_text()
+    mods = Path(sys.argv[2]).read_text()
 
     result = {"publication": {}, "errors": []}
     try:

--- a/misc/mods_to_json.py
+++ b/misc/mods_to_json.py
@@ -1,0 +1,26 @@
+import json
+from os import path, sys
+from pathlib import Path
+import re
+
+from flask import jsonify
+
+from pipeline.convert import ModsParser
+
+FILE_PATH = path.dirname(path.abspath(__file__))
+XSLT = Path(f"{FILE_PATH}/../resources/mods_to_xjsonld.xsl").read_text()
+
+if __name__ == "__main__":
+    if len(sys.argv) == 1:
+        print(f"Usage: in swepub-redux: python3 -m misc.mods_to_json <path-record-in-MODS-xml>")
+        sys.exit(1)
+
+    mods = Path(sys.argv[1]).read_text()
+
+    result = {"publication": {}, "errors": []}
+    try:
+        result["publication"] = ModsParser().parse_mods(mods, encode_ampersand=True)
+    except LxmlError as e:
+        result["errors"] = [{"message": str(e)}]
+
+    print(json.dumps({"result": result["publication"], "error": result["errors"]}, indent=4))

--- a/pipeline/tests/converter/test_parser.py
+++ b/pipeline/tests/converter/test_parser.py
@@ -3343,6 +3343,8 @@ def test_several_access_policies(parser):
     assert expected_usage_and_access_policy == parsed_policy
 
 
+# Tests related to changes in Swepub MODS 4.0 below
+
 def test_origininfo_eventtype_publication_1(parser):
     raw_xml = MODS("""
         <originInfo eventType="publication">

--- a/pipeline/tests/converter/test_parser.py
+++ b/pipeline/tests/converter/test_parser.py
@@ -2633,132 +2633,10 @@ def test_agent_is_extracted_as_provision_activity_agent(parser):
     assert actual == expected
 
 
-def test_agent_is_extracted_as_provision_activity_agent_2(parser):
-    raw_xml = MODS("""
-        <originInfo eventType="publication">
-            <agent>
-                <namePart>Cambridge University Press</namePart>
-                <role>
-                    <roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/pbl">pbl</roleTerm>
-                </role>
-            </agent>
-        </originInfo>
-    """)
-
-    actual = parser.parse_mods(raw_xml)['publication']
-    expected = [
-        {
-            '@type': 'Publication',
-            'agent': {
-                '@type': 'Agent',
-                'label': 'Cambridge University Press'
-            }
-        }
-    ]
-
-    assert actual == expected
-
-
-def test_agent_is_extracted_as_provision_activity_agent_3(parser):
-    raw_xml = MODS("""
-        <originInfo eventType="publication">
-            <agent>
-                <namePart>Cambridge University Press</namePart>
-                <role>
-                    <roleTerm authority="marcrelator">pbl</roleTerm>
-                </role>
-            </agent>
-        </originInfo>
-    """)
-
-    actual = parser.parse_mods(raw_xml)['publication']
-    expected = [
-        {
-            '@type': 'Publication',
-            'agent': {
-                '@type': 'Agent',
-                'label': 'Cambridge University Press'
-            }
-        }
-    ]
-
-    assert actual == expected
-
-
-def test_agent_is_extracted_as_provision_activity_agent_4(parser):
-    raw_xml = MODS("""
-        <originInfo eventType="publication">
-            <agent>
-                <namePart>Cambridge University Press</namePart>
-                <role>
-                    <roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/pbl"></roleTerm>
-                </role>
-            </agent>
-        </originInfo>
-    """)
-
-    actual = parser.parse_mods(raw_xml)['publication']
-    expected = [
-        {
-            '@type': 'Publication',
-            'agent': {
-                '@type': 'Agent',
-                'label': 'Cambridge University Press'
-            }
-        }
-    ]
-
-    assert actual == expected
-
-
-def test_agent_is_not_extracted_as_provision_activity_agent_if_roleterm_stuff_missing(parser):
-    raw_xml = MODS("""
-        <originInfo eventType="publication">
-            <agent>
-                <namePart>Cambridge University Press</namePart>
-                <role>
-                    <roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/foo">bar</roleTerm>
-                </role>
-            </agent>
-        </originInfo>
-    """)
-
-    assert "publication" not in parser.parse_mods(raw_xml)
-
-
 def test_complete_origin_info(parser):
     raw_xml = MODS("""
         <originInfo>
             <publisher>Cambridge University Press</publisher>
-            <dateIssued>1986-05-30</dateIssued>
-            <place>
-                <placeTerm>Ankeborg</placeTerm>
-            </place>
-        </originInfo>
-    """)
-
-    actual = parser.parse_mods(raw_xml)['publication']
-    expected = [
-        {
-            '@type': 'Publication',
-            'date': '1986-05-30',
-            'place': {'@type': 'Place', 'label': 'Ankeborg'},
-            'agent': {'@type': 'Agent', 'label': 'Cambridge University Press'}
-        }
-    ]
-
-    assert actual == expected
-
-
-def test_complete_origin_info_2(parser):
-    raw_xml = MODS("""
-        <originInfo eventType="publication">
-            <agent>
-                <namePart>Cambridge University Press</namePart>
-                <role>
-                    <roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/pbl">pbl</roleTerm>
-                </role>
-            </agent>
             <dateIssued>1986-05-30</dateIssued>
             <place>
                 <placeTerm>Ankeborg</placeTerm>
@@ -3463,3 +3341,339 @@ def test_several_access_policies(parser):
     parsed_policy = parser.parse_mods(raw_xml)['usageAndAccessPolicy']
     print(f"{parsed_policy}")
     assert expected_usage_and_access_policy == parsed_policy
+
+
+def test_origininfo_eventtype_publication_1(parser):
+    raw_xml = MODS("""
+        <originInfo eventType="publication">
+            <agent>
+                <namePart>Cambridge University Press</namePart>
+                <role>
+                    <roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/pbl">pbl</roleTerm>
+                </role>
+            </agent>
+        </originInfo>
+    """)
+
+    actual = parser.parse_mods(raw_xml)['publication']
+    expected = [
+        {
+            '@type': 'Publication',
+            'agent': {
+                '@type': 'Agent',
+                'label': 'Cambridge University Press'
+            }
+        }
+    ]
+
+    assert actual == expected
+
+
+def test_origininfo_eventtype_publication_2(parser):
+    raw_xml = MODS("""
+        <originInfo eventType="publication">
+            <agent>
+                <namePart>Cambridge University Press</namePart>
+                <role>
+                    <roleTerm authority="marcrelator">pbl</roleTerm>
+                </role>
+            </agent>
+        </originInfo>
+    """)
+
+    actual = parser.parse_mods(raw_xml)['publication']
+    expected = [
+        {
+            '@type': 'Publication',
+            'agent': {
+                '@type': 'Agent',
+                'label': 'Cambridge University Press'
+            }
+        }
+    ]
+
+    assert actual == expected
+
+
+def test_origininfo_eventtype_publication_3(parser):
+    raw_xml = MODS("""
+        <originInfo eventType="publication">
+            <agent>
+                <namePart>Cambridge University Press</namePart>
+                <role>
+                    <roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/pbl"></roleTerm>
+                </role>
+            </agent>
+        </originInfo>
+    """)
+
+    actual = parser.parse_mods(raw_xml)['publication']
+    expected = [
+        {
+            '@type': 'Publication',
+            'agent': {
+                '@type': 'Agent',
+                'label': 'Cambridge University Press'
+            }
+        }
+    ]
+
+    assert actual == expected
+
+
+def test_origininfo_eventtype_publication_4(parser):
+    raw_xml = MODS("""
+        <originInfo eventType="publication">
+            <agent>
+                <namePart>Cambridge University Press</namePart>
+                <role>
+                    <roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/foo">bar</roleTerm>
+                </role>
+            </agent>
+        </originInfo>
+    """)
+
+    assert "publication" not in parser.parse_mods(raw_xml)
+
+
+def test_origininfo_eventtype_manufacture(parser):
+    raw_xml = MODS("""
+        <originInfo eventType="manufacture">
+            <agent>
+                <namePart>Cambridge University Press</namePart>
+                <role>
+                    <roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/mfr">mfr</roleTerm>
+                </role>
+            </agent>
+        </originInfo>
+    """)
+
+    actual = parser.parse_mods(raw_xml)['manufacture']
+    expected = [
+        {
+            '@type': 'Manufacture',
+            'agent': {
+                '@type': 'Agent',
+                'label': 'Cambridge University Press'
+            }
+        }
+    ]
+
+    assert actual == expected
+
+
+def test_origininfo_eventtype_distribution(parser):
+    raw_xml = MODS("""
+        <originInfo eventType="distribution">
+            <agent>
+                <namePart>Cambridge University Press</namePart>
+                <role>
+                    <roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/dst">dst</roleTerm>
+                </role>
+            </agent>
+        </originInfo>
+    """)
+
+    actual = parser.parse_mods(raw_xml)['distribution']
+    expected = [
+        {
+            '@type': 'Distribution',
+            'agent': {
+                '@type': 'Agent',
+                'label': 'Cambridge University Press'
+            }
+        }
+    ]
+
+    assert actual == expected
+
+
+def test_origininfo_eventtype_production(parser):
+    raw_xml = MODS("""
+        <originInfo eventType="production">
+            <agent>
+                <namePart>Cambridge University Press</namePart>
+                <role>
+                    <roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/pro">pro</roleTerm>
+                </role>
+            </agent>
+        </originInfo>
+    """)
+
+    actual = parser.parse_mods(raw_xml)['production']
+    expected = [
+        {
+            '@type': 'Production',
+            'agent': {
+                '@type': 'Agent',
+                'label': 'Cambridge University Press'
+            }
+        }
+    ]
+
+    assert actual == expected
+
+
+def test_origininfo_other(parser):
+    raw_xml = MODS("""
+        <originInfo>
+            <agent>
+                <namePart>Cambridge University Press</namePart>
+                <role>
+                    <roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/prt">prt</roleTerm>
+                </role>
+            </agent>
+        </originInfo>
+    """)
+
+    actual = parser.parse_mods(raw_xml)['contribution']
+    expected = [
+        {
+            '@type': 'Contribution',
+            'agent': {
+                '@type': 'Agent',
+                'label': 'Cambridge University Press',
+                'role': [
+                    {
+                        '@id': 'http://id.loc.gov/vocabulary/relators/prt'
+                    }
+                ]
+            }
+        }
+    ]
+
+    assert actual == expected
+
+
+def test_origininfo_other_2(parser):
+    raw_xml = MODS("""
+        <originInfo eventType="somethingelse">
+            <agent>
+                <namePart>Cambridge University Press</namePart>
+                <role>
+                    <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/something" />
+                </role>
+            </agent>
+        </originInfo>
+    """)
+
+    actual = parser.parse_mods(raw_xml)['contribution']
+    expected = [
+        {
+            '@type': 'Contribution',
+            'agent': {
+                '@type': 'Agent',
+                'label': 'Cambridge University Press',
+                'role': [
+                    {
+                        '@id': 'http://id.loc.gov/vocabulary/relators/something'
+                    }
+                ]
+            }
+        }
+    ]
+
+    assert actual == expected
+
+
+def test_complete_origin_info_2(parser):
+    raw_xml = MODS("""
+        <originInfo eventType="publication">
+            <agent>
+                <namePart>Cambridge University Press</namePart>
+                <role>
+                    <roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/pbl">pbl</roleTerm>
+                </role>
+            </agent>
+            <dateIssued>1986-05-30</dateIssued>
+            <place>
+                <placeTerm>Ankeborg</placeTerm>
+            </place>
+        </originInfo>
+    """)
+
+    actual = parser.parse_mods(raw_xml)['publication']
+    expected = [
+        {
+            '@type': 'Publication',
+            'date': '1986-05-30',
+            'place': {'@type': 'Place', 'label': 'Ankeborg'},
+            'agent': {'@type': 'Agent', 'label': 'Cambridge University Press'}
+        }
+    ]
+
+    assert actual == expected
+
+
+def test_complete_origin_info_3(parser):
+    raw_xml = MODS("""
+        <originInfo eventType="publication">
+            <agent>
+                <namePart>Elsevier</namePart>
+                <role>
+                    <roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/pbl">pbl</roleTerm>
+                </role>
+            </agent>
+            <dateIssued>1986-05-30</dateIssued>
+            <dateOther type="available">2017-09-28T11:03:29</dateOther>
+            <place>
+                <placeTerm>Ankeborg</placeTerm>
+            </place>
+        </originInfo>
+        <originInfo eventType="manufacture">
+            <agent>
+                <namePart>Cambridge University Press</namePart>
+                <role>
+                    <roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/mfr">mfr</roleTerm>
+                </role>
+            </agent>
+            <dateOther type="digitized">2022-07-25T20:05:30</dateOther>
+        </originInfo>
+        <originInfo eventType="distribution">
+            <agent>
+                <namePart>Cambridge University Press</namePart>
+                <role>
+                    <roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/pbl">pbl</roleTerm>
+                </role>
+            </agent>
+        </originInfo>
+    """)
+
+    actual = parser.parse_mods(raw_xml)
+    expected_publication = [
+        {
+            '@type': 'Publication',
+            'date': '1986-05-30',
+            'place': {
+                '@type': 'Place',
+                'label': 'Ankeborg'
+            },
+            'agent': {
+                '@type': 'Agent',
+                'label': 'Elsevier'
+            }
+        }
+    ]
+    expected_manufacture = [
+        {
+            '@type': 'Manufacture',
+            'agent': {
+                '@type': 'Agent',
+                'label': 'Cambridge University Press'
+            }
+        }
+    ]
+    expected_provisionactivity = [
+        {
+            "@type": "Availability",
+            "date": "2017-09-28T11:03:29"
+        },
+        {
+            "@type": "Digitization",
+            "date": "2022-07-25T20:05:30"
+        }
+    ]
+
+    assert actual["publication"] == expected_publication
+    assert actual["manufacture"] == expected_manufacture
+    assert actual["provisionActivity"] == expected_provisionactivity

--- a/pipeline/tests/converter/test_parser.py
+++ b/pipeline/tests/converter/test_parser.py
@@ -2633,10 +2633,132 @@ def test_agent_is_extracted_as_provision_activity_agent(parser):
     assert actual == expected
 
 
+def test_agent_is_extracted_as_provision_activity_agent_2(parser):
+    raw_xml = MODS("""
+        <originInfo eventType="publication">
+            <agent>
+                <namePart>Cambridge University Press</namePart>
+                <role>
+                    <roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/pbl">pbl</roleTerm>
+                </role>
+            </agent>
+        </originInfo>
+    """)
+
+    actual = parser.parse_mods(raw_xml)['publication']
+    expected = [
+        {
+            '@type': 'Publication',
+            'agent': {
+                '@type': 'Agent',
+                'label': 'Cambridge University Press'
+            }
+        }
+    ]
+
+    assert actual == expected
+
+
+def test_agent_is_extracted_as_provision_activity_agent_3(parser):
+    raw_xml = MODS("""
+        <originInfo eventType="publication">
+            <agent>
+                <namePart>Cambridge University Press</namePart>
+                <role>
+                    <roleTerm authority="marcrelator">pbl</roleTerm>
+                </role>
+            </agent>
+        </originInfo>
+    """)
+
+    actual = parser.parse_mods(raw_xml)['publication']
+    expected = [
+        {
+            '@type': 'Publication',
+            'agent': {
+                '@type': 'Agent',
+                'label': 'Cambridge University Press'
+            }
+        }
+    ]
+
+    assert actual == expected
+
+
+def test_agent_is_extracted_as_provision_activity_agent_4(parser):
+    raw_xml = MODS("""
+        <originInfo eventType="publication">
+            <agent>
+                <namePart>Cambridge University Press</namePart>
+                <role>
+                    <roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/pbl"></roleTerm>
+                </role>
+            </agent>
+        </originInfo>
+    """)
+
+    actual = parser.parse_mods(raw_xml)['publication']
+    expected = [
+        {
+            '@type': 'Publication',
+            'agent': {
+                '@type': 'Agent',
+                'label': 'Cambridge University Press'
+            }
+        }
+    ]
+
+    assert actual == expected
+
+
+def test_agent_is_not_extracted_as_provision_activity_agent_if_roleterm_stuff_missing(parser):
+    raw_xml = MODS("""
+        <originInfo eventType="publication">
+            <agent>
+                <namePart>Cambridge University Press</namePart>
+                <role>
+                    <roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/foo">bar</roleTerm>
+                </role>
+            </agent>
+        </originInfo>
+    """)
+
+    assert "publication" not in parser.parse_mods(raw_xml)
+
+
 def test_complete_origin_info(parser):
     raw_xml = MODS("""
         <originInfo>
             <publisher>Cambridge University Press</publisher>
+            <dateIssued>1986-05-30</dateIssued>
+            <place>
+                <placeTerm>Ankeborg</placeTerm>
+            </place>
+        </originInfo>
+    """)
+
+    actual = parser.parse_mods(raw_xml)['publication']
+    expected = [
+        {
+            '@type': 'Publication',
+            'date': '1986-05-30',
+            'place': {'@type': 'Place', 'label': 'Ankeborg'},
+            'agent': {'@type': 'Agent', 'label': 'Cambridge University Press'}
+        }
+    ]
+
+    assert actual == expected
+
+
+def test_complete_origin_info_2(parser):
+    raw_xml = MODS("""
+        <originInfo eventType="publication">
+            <agent>
+                <namePart>Cambridge University Press</namePart>
+                <role>
+                    <roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/pbl">pbl</roleTerm>
+                </role>
+            </agent>
             <dateIssued>1986-05-30</dateIssued>
             <place>
                 <placeTerm>Ankeborg</placeTerm>

--- a/resources/mods_to_xjsonld.xsl
+++ b/resources/mods_to_xjsonld.xsl
@@ -247,7 +247,7 @@
                 </dict>
             </xsl:if>
             <xsl:if test="mods:originInfo">
-                <xsl:if test="mods:originInfo/mods:publisher or mods:originInfo/mods:place or mods:originInfo/mods:dateIssued">
+                <xsl:if test="mods:originInfo/mods:publisher or mods:originInfo/mods:place or mods:originInfo/mods:dateIssued or (mods:originInfo[@eventType = 'publication'] and (mods:originInfo/mods:agent/mods:role/mods:roleTerm[.='pbl'] or mods:originInfo/mods:agent/mods:role/mods:roleTerm[@valueURI = 'http://id.loc.gov/vocabulary/relators/pbl']))">
                     <array key="publication">
                         <dict>
                             <string key="@type">Publication</string>
@@ -255,6 +255,12 @@
                                 <dict key="agent">
                                     <string key="@type">Agent</string>
                                     <string key="label"><xsl:value-of select="mods:originInfo/mods:publisher"/></string>
+                                </dict>
+                            </xsl:if>
+                            <xsl:if test="mods:originInfo/mods:agent/mods:namePart">
+                                <dict key="agent">
+                                    <string key="@type">Agent</string>
+                                    <string key="label"><xsl:value-of select="mods:originInfo/mods:agent/mods:namePart"/></string>
                                 </dict>
                             </xsl:if>
                             <xsl:if test="mods:originInfo/mods:place/mods:placeTerm">

--- a/resources/mods_to_xjsonld.xsl
+++ b/resources/mods_to_xjsonld.xsl
@@ -246,39 +246,173 @@
                     </xsl:if>
                 </dict>
             </xsl:if>
+
             <xsl:if test="mods:originInfo">
-                <xsl:if test="mods:originInfo/mods:publisher or mods:originInfo/mods:place or mods:originInfo/mods:dateIssued or (mods:originInfo[@eventType = 'publication'] and (mods:originInfo/mods:agent/mods:role/mods:roleTerm[.='pbl'] or mods:originInfo/mods:agent/mods:role/mods:roleTerm[@valueURI = 'http://id.loc.gov/vocabulary/relators/pbl']))">
+                <!-- If originInfo has *no* attributes *and* certain elements, *or* the attribute eventType='publication' and certain elements, consider it to be a publication -->
+                <xsl:if test="(mods:originInfo[not(@*)] and (mods:originInfo/mods:publisher or mods:originInfo/mods:place or mods:originInfo/mods:dateIssued)) or (mods:originInfo[@eventType = 'publication'] and (mods:originInfo/mods:agent/mods:role/mods:roleTerm[.='pbl'] or mods:originInfo/mods:agent/mods:role/mods:roleTerm[@valueURI = 'http://id.loc.gov/vocabulary/relators/pbl']))">
                     <array key="publication">
-                        <dict>
-                            <string key="@type">Publication</string>
-                            <xsl:if test="mods:originInfo/mods:publisher">
-                                <dict key="agent">
-                                    <string key="@type">Agent</string>
-                                    <string key="label"><xsl:value-of select="mods:originInfo/mods:publisher"/></string>
+                        <xsl:for-each select="mods:originInfo[not(@*) or @eventType = 'publication']">
+                            <xsl:if test="mods:publisher or mods:place or mods:dateIssued or (@eventType = 'publication' and (mods:agent/mods:role/mods:roleTerm[.='pbl'] or mods:agent/mods:role/mods:roleTerm[@valueURI = 'http://id.loc.gov/vocabulary/relators/pbl']))">
+                                <dict>
+                                    <string key="@type">Publication</string>
+                                    <xsl:if test="mods:publisher">
+                                        <dict key="agent">
+                                            <string key="@type">Agent</string>
+                                            <string key="label"><xsl:value-of select="mods:publisher"/></string>
+                                        </dict>
+                                    </xsl:if>
+                                    <xsl:if test="mods:agent/mods:namePart">
+                                        <dict key="agent">
+                                            <string key="@type">Agent</string>
+                                            <string key="label"><xsl:value-of select="mods:agent/mods:namePart"/></string>
+                                        </dict>
+                                    </xsl:if>
+                                    <xsl:if test="mods:place/mods:placeTerm">
+                                        <dict key="place">
+                                            <string key="@type">Place</string>
+                                            <string key="label"><xsl:value-of select="mods:place/mods:placeTerm"/></string>
+                                        </dict>
+                                    </xsl:if>
+                                    <xsl:if test="mods:dateIssued">
+                                        <string key="date">
+                                            <xsl:call-template name="date">
+                                                <xsl:with-param name="date" select="mods:dateIssued" />
+                                            </xsl:call-template>
+                                        </string>
+                                    </xsl:if>
                                 </dict>
                             </xsl:if>
-                            <xsl:if test="mods:originInfo/mods:agent/mods:namePart">
-                                <dict key="agent">
-                                    <string key="@type">Agent</string>
-                                    <string key="label"><xsl:value-of select="mods:originInfo/mods:agent/mods:namePart"/></string>
-                                </dict>
-                            </xsl:if>
-                            <xsl:if test="mods:originInfo/mods:place/mods:placeTerm">
-                                <dict key="place">
-                                    <string key="@type">Place</string>
-                                    <string key="label"><xsl:value-of select="mods:originInfo/mods:place/mods:placeTerm"/></string>
-                                </dict>
-                            </xsl:if>
-                            <xsl:if test="mods:originInfo/mods:dateIssued">
-                                <string key="date">
-                                    <xsl:call-template name="date">
-                                        <xsl:with-param name="date" select="mods:originInfo/mods:dateIssued" />
-                                    </xsl:call-template>
-                                </string>
-                            </xsl:if>
-                        </dict>
-                    </array>>
+                        </xsl:for-each>
+                    </array>
                 </xsl:if>
+
+                <xsl:if test="mods:originInfo[@eventType = 'manufacture'] and (mods:originInfo/mods:agent/mods:role/mods:roleTerm[.='mfr'] or mods:originInfo/mods:agent/mods:role/mods:roleTerm[@valueURI = 'http://id.loc.gov/vocabulary/relators/mfr'])">
+                    <array key="manufacture">
+                        <xsl:for-each select="mods:originInfo[@eventType = 'manufacture']">
+                            <xsl:if test="mods:agent/mods:role/mods:roleTerm[.='mfr'] or mods:agent/mods:role/mods:roleTerm[@valueURI = 'http://id.loc.gov/vocabulary/relators/mfr']">
+                                <dict>
+                                    <string key="@type">Manufacture</string>
+                                    <xsl:if test="mods:agent/mods:namePart">
+                                        <dict key="agent">
+                                            <string key="@type">Agent</string>
+                                            <string key="label"><xsl:value-of select="mods:agent/mods:namePart"/></string>
+                                        </dict>
+                                    </xsl:if>
+                                    <xsl:if test="mods:place/mods:placeTerm">
+                                        <dict key="place">
+                                            <string key="@type">Place</string>
+                                            <string key="label"><xsl:value-of select="mods:place/mods:placeTerm"/></string>
+                                        </dict>
+                                    </xsl:if>
+                                </dict>
+                            </xsl:if>
+                        </xsl:for-each>
+                    </array>
+                </xsl:if>
+
+                <xsl:if test="mods:originInfo[@eventType = 'distribution'] and (mods:originInfo/mods:agent/mods:role/mods:roleTerm[.='dst'] or mods:originInfo/mods:agent/mods:role/mods:roleTerm[@valueURI = 'http://id.loc.gov/vocabulary/relators/dst'])">
+                    <array key="distribution">
+                        <xsl:for-each select="mods:originInfo[@eventType = 'distribution']">
+                            <xsl:if test="mods:agent/mods:role/mods:roleTerm[.='dst'] or mods:agent/mods:role/mods:roleTerm[@valueURI = 'http://id.loc.gov/vocabulary/relators/dst']">
+                                <dict>
+                                    <string key="@type">Distribution</string>
+                                    <xsl:if test="mods:agent/mods:namePart">
+                                        <dict key="agent">
+                                            <string key="@type">Agent</string>
+                                            <string key="label"><xsl:value-of select="mods:agent/mods:namePart"/></string>
+                                        </dict>
+                                    </xsl:if>
+                                    <xsl:if test="mods:place/mods:placeTerm">
+                                        <dict key="place">
+                                            <string key="@type">Place</string>
+                                            <string key="label"><xsl:value-of select="mods:place/mods:placeTerm"/></string>
+                                        </dict>
+                                    </xsl:if>
+                                </dict>
+                            </xsl:if>
+                        </xsl:for-each>
+                    </array>
+                </xsl:if>
+
+                <xsl:if test="mods:originInfo[@eventType = 'production'] and (mods:originInfo/mods:agent/mods:role/mods:roleTerm[.='pro'] or mods:originInfo/mods:agent/mods:role/mods:roleTerm[@valueURI = 'http://id.loc.gov/vocabulary/relators/pro'])">
+                    <array key="production">
+                        <xsl:for-each select="mods:originInfo[@eventType = 'production']">
+                            <xsl:if test="mods:agent/mods:role/mods:roleTerm[.='pro'] or mods:agent/mods:role/mods:roleTerm[@valueURI = 'http://id.loc.gov/vocabulary/relators/pro']">
+                                <dict>
+                                    <string key="@type">Production</string>
+                                    <xsl:if test="mods:agent/mods:namePart">
+                                        <dict key="agent">
+                                            <string key="@type">Agent</string>
+                                            <string key="label"><xsl:value-of select="mods:agent/mods:namePart"/></string>
+                                        </dict>
+                                    </xsl:if>
+                                    <xsl:if test="mods:place/mods:placeTerm">
+                                        <dict key="place">
+                                            <string key="@type">Place</string>
+                                            <string key="label"><xsl:value-of select="mods:place/mods:placeTerm"/></string>
+                                        </dict>
+                                    </xsl:if>
+                                </dict>
+                            </xsl:if>
+                        </xsl:for-each>
+                    </array>
+                </xsl:if>
+
+                <!-- Yes, this is a mess. -->
+                <xsl:variable name="hasContribution">
+                    <xsl:for-each select="mods:originInfo">
+                        <xsl:variable name="roleTerm" select="mods:agent/mods:role/mods:roleTerm" />
+                        <xsl:variable name="roleTermValueURI" select="mods:agent/mods:role/mods:roleTerm[@valueURI]" />
+                        <xsl:if test="
+                            mods:agent/mods:role/mods:roleTerm
+                            and not($roleTerm = 'pbl' or $roleTerm = 'mfr' or $roleTerm = 'dst' or $roleTerm = 'pro')
+                            and not($roleTermValueURI = 'http://id.loc.gov/vocabulary/relators/pbl' or $roleTermValueURI = 'http://id.loc.gov/vocabulary/relators/mfr' or $roleTermValueURI = 'http://id.loc.gov/vocabulary/relators/dst' or $roleTermValueURI = 'http://id.loc.gov/vocabulary/relators/pro')
+                        ">
+                            <xsl:value-of select="'true'"/>
+                        </xsl:if>
+                    </xsl:for-each>
+                </xsl:variable>
+
+                <xsl:if test="$hasContribution = 'true'">
+                    <array key="contribution">
+                        <xsl:for-each select="mods:originInfo">
+                            <xsl:variable name="roleTerm" select="mods:agent/mods:role/mods:roleTerm" />
+                            <xsl:variable name="roleTermValueURI" select="mods:agent/mods:role/mods:roleTerm[@valueURI]" />
+                            <xsl:if test="
+                                mods:agent/mods:role/mods:roleTerm
+                                and not($roleTerm = 'pbl' or $roleTerm = 'mfr' or $roleTerm = 'dst' or $roleTerm = 'pro')
+                                and not($roleTermValueURI = 'http://id.loc.gov/vocabulary/relators/pbl' or $roleTermValueURI = 'http://id.loc.gov/vocabulary/relators/mfr' or $roleTermValueURI = 'http://id.loc.gov/vocabulary/relators/dst' or $roleTermValueURI = 'http://id.loc.gov/vocabulary/relators/pro')
+                            ">
+                                <dict>
+                                    <string key="@type">Contribution</string>
+                                    <xsl:if test="mods:agent/mods:namePart">
+                                        <dict key="agent">
+                                            <string key="@type">Agent</string>
+                                            <string key="label"><xsl:value-of select="mods:agent/mods:namePart"/></string>
+                                            <array key="role">
+                                                <dict>
+                                                    <xsl:if test="mods:agent/mods:role/mods:roleTerm">
+                                                        <string key="@id">http://id.loc.gov/vocabulary/relators/<xsl:value-of select="mods:agent/mods:role/mods:roleTerm"/></string>
+                                                    </xsl:if>
+                                                    <xsl:if test="mods:agent/mods:role/mods:roleTerm[@valueURI]">
+                                                        <string key="@id"><xsl:value-of select="mods:agent/mods:role/mods:roleTerm/@valueURI"/></string>
+                                                    </xsl:if>
+                                                </dict>
+                                            </array>
+                                        </dict>
+                                    </xsl:if>
+                                    <xsl:if test="mods:place/mods:placeTerm">
+                                        <dict key="place">
+                                            <string key="@type">Place</string>
+                                            <string key="label"><xsl:value-of select="mods:place/mods:placeTerm"/></string>
+                                        </dict>
+                                    </xsl:if>
+                                </dict>
+                            </xsl:if>
+                        </xsl:for-each>
+                    </array>
+                </xsl:if>
+
                 <xsl:if test="mods:originInfo/mods:dateOther">
                     <xsl:for-each select="mods:originInfo/mods:dateOther[@type = 'defence']">
                         <array key="dissertation">
@@ -337,6 +471,7 @@
                     </string>
                 </xsl:if>
             </xsl:if>
+
             <xsl:if test="mods:location">
                   <array key="electronicLocator">
                     <xsl:for-each select="mods:location/*">


### PR DESCRIPTION
https://jira.kb.se/browse/SWEPUB2-1106

This is a bit messy but Seems To Work (tm) and my XSLT-fu isn't strong enough to come up with anything better.

Also added a simple utility script to answer the question "using `<XSLT file>`, what will `<record XML in Swepub MODS>` look like in JSON-LD?". Just to make experimenting with XSLT changes easier. Example workflow:
```
python3 -m misc.fetch_records oai:DiVA.org:uniarts-1011
xmllint --format _xml/uniarts/oaiDiVA.orguniarts-1011.xml > foo.tmp && mv foo.tmp _xml/uniarts/oaiDiVA.orguniarts-1011.xml # just to make it prettier
# ... make some changes in xsl or xml ... 
python3 -m misc.mods_to_json resources/mods_to_xjsonld.xsl _xml/uniarts/oaiDiVA.orguniarts-1011.xml
```