### PR TITLE
Merge affiliations in some cases; make it possible to use ROR ID in affiliations

### DIFF
--- a/pipeline/audit.py
+++ b/pipeline/audit.py
@@ -1,5 +1,6 @@
 from functools import reduce
 
+from pipeline.auditors.modsfixer import ModsFixer
 from pipeline.auditors.swedishlist import SwedishListAuditor
 from pipeline.auditors.creatorcount import CreatorCountAuditor
 from pipeline.auditors.uka import UKAAuditor
@@ -12,6 +13,7 @@ from pipeline.auditors.crossref import CrossrefAuditor
 from pipeline.publication import Publication
 
 AUDITORS = [
+    ModsFixer(),
     SwedishListAuditor(),
     CreatorCountAuditor(),
     ContributorAuditor(),

--- a/pipeline/auditors/modsfixer.py
+++ b/pipeline/auditors/modsfixer.py
@@ -1,5 +1,3 @@
-import re
-
 from pipeline.auditors import BaseAuditor
 
 

--- a/pipeline/auditors/modsfixer.py
+++ b/pipeline/auditors/modsfixer.py
@@ -1,0 +1,60 @@
+import re
+
+from pipeline.auditors import BaseAuditor
+
+
+class ModsFixer(BaseAuditor):
+    """A class to do things that should've ideally been done in the MODS-to-JSON-LD XSLT, but weren't possible for some reason."""
+
+
+    def __init__(self):
+        self.name = ModsFixer.__name__
+
+
+    def audit(self, publication, audit_events, _harvest_cache, _session):
+        for contribution in publication.contributions:
+            contribution.affiliations = self._handle_affiliations(contribution.affiliations)
+        return publication, audit_events
+
+
+    # Merges affiliations that refer to the same thing but have been split up by language
+    def _handle_affiliations(self, affiliations):
+        grouped = {}
+        not_grouped = []
+        kb_se_count = 0
+        kb_se_langs = set()
+
+        for affiliation in affiliations:
+            if affiliation.get("identifiedBy"):
+                if affiliation["identifiedBy"][0].get("source", {}).get("code", "") == "kb.se":
+                    kb_se_count += 1
+            language = list(affiliation.get("nameByLang", {}))
+            if language:
+                kb_se_langs.add(language[0])
+
+        for affiliation in affiliations:
+            id_by = affiliation.get("identifiedBy", [])
+            if id_by and affiliation.get("nameByLang"):
+                language, name = list(affiliation.get("nameByLang").items())[0]
+                id_by_value = id_by[0].get("value", "")
+
+                key = None
+                # Merge affiliations that have @type ROR and the same identifiedBy value (i.e., ROR ID).
+                if id_by[0].get("@type", "") == "ROR":
+                    key = f"ROR-{id_by_value}"
+                # If we have two affiliations with source/authority kb.se and identical identifiedBy value
+                # *AND* they have *different* languages, we merge them into one; if they have the same
+                # language, we don't, because in that case they probably express specific institutions. 
+                elif id_by[0].get("source", {}).get("code", "") == "kb.se" and kb_se_count == 2 and len(kb_se_langs) == 2:
+                    key = f"kb.se-{id_by_value}"
+
+                if key:
+                    if key not in grouped:
+                        grouped[key] = {'@type': 'Organization', 'nameByLang': {}, 'identifiedBy': id_by}
+                    grouped[key]['nameByLang'][language] = name
+                else:
+                    not_grouped.append(affiliation)
+            else:
+                not_grouped.append(affiliation)
+
+        return [v for _k, v in grouped.items()] + not_grouped

--- a/pipeline/tests/auditors/test_modsfixer.py
+++ b/pipeline/tests/auditors/test_modsfixer.py
@@ -1,0 +1,290 @@
+from pipeline.auditors.modsfixer import ModsFixer
+from pipeline.publication import Publication
+
+modsfixer = ModsFixer()
+
+body = {
+    "instanceOf": {
+        "contribution": [
+            {
+                "@type": "Contribution",
+                "agent": {
+                    "@type": "Person",
+                    "familyName": "Bar",
+                    "givenName": "Foo",
+                },
+                "hasAffiliation": [
+                    {
+                        "@type": "Organization",
+                        "identifiedBy": [
+                            {
+                                "@type": "URI",
+                                "source": {"@type": "Source", "code": "kb.se"},
+                                "value": "example.com",
+                            }
+                        ],
+                        "nameByLang": {"swe": "authority kb.se, svenska"},
+                    },
+                    {
+                        "@type": "Organization",
+                        "identifiedBy": [
+                            {
+                                "@type": "URI",
+                                "source": {"@type": "Source", "code": "kb.se"},
+                                "value": "example.com",
+                            }
+                        ],
+                        "nameByLang": {"eng": "authority kb.se, English"},
+                    },
+                    {
+                        "@type": "Organization",
+                        "identifiedBy": [
+                            {"@type": "ROR", "value": "https://ror.org/12345"}
+                        ],
+                        "nameByLang": {"eng": "ROR org in English"},
+                    },
+                    {
+                        "@type": "Organization",
+                        "identifiedBy": [
+                            {"@type": "ROR", "value": "https://ror.org/12345"}
+                        ],
+                        "nameByLang": {"swe": "ROR-org på svenska"},
+                    },
+                    {"@type": "Organization", "name": "Org without language specified"},
+                ],
+            }
+        ]
+    }
+}
+
+
+def test_should_merge_identical_ror_ids():
+    publication = Publication(
+        {
+            "instanceOf": {
+                "contribution": [
+                    {
+                        "@type": "Contribution",
+                        "agent": {
+                            "@type": "Person",
+                            "familyName": "Bar",
+                            "givenName": "Foo",
+                        },
+                        "hasAffiliation": [
+                            {
+                                "@type": "Organization",
+                                "identifiedBy": [
+                                    {"@type": "ROR", "value": "https://ror.org/12345"}
+                                ],
+                                "nameByLang": {"eng": "ROR org in English"},
+                            },
+                            {
+                                "@type": "Organization",
+                                "identifiedBy": [
+                                    {"@type": "ROR", "value": "https://ror.org/12345"}
+                                ],
+                                "nameByLang": {"swe": "ROR-org på svenska"},
+                            },
+                            {
+                                "@type": "Organization",
+                                "name": "Org without language specified",
+                            },
+                        ],
+                    }
+                ]
+            }
+        }
+    )
+
+    new_publication, _audit_events = modsfixer.audit(publication, [], None, None)
+
+    assert new_publication.contributions[0].affiliations == [
+        {
+            "@type": "Organization",
+            "nameByLang": {"eng": "ROR org in English", "swe": "ROR-org på svenska"},
+            "identifiedBy": [{"@type": "ROR", "value": "https://ror.org/12345"}],
+        },
+        {"@type": "Organization", "name": "Org without language specified"},
+    ]
+
+
+def test_should_not_merge_nonidentical_ror_ids():
+    publication = Publication(
+        {
+            "instanceOf": {
+                "contribution": [
+                    {
+                        "@type": "Contribution",
+                        "agent": {
+                            "@type": "Person",
+                            "familyName": "Bar",
+                            "givenName": "Foo",
+                        },
+                        "hasAffiliation": [
+                            {
+                                "@type": "Organization",
+                                "identifiedBy": [
+                                    {"@type": "ROR", "value": "https://ror.org/12345"}
+                                ],
+                                "nameByLang": {"eng": "ROR org in English"},
+                            },
+                            {
+                                "@type": "Organization",
+                                "identifiedBy": [
+                                    {"@type": "ROR", "value": "https://ror.org/67890"}
+                                ],
+                                "nameByLang": {"swe": "ROR-org på svenska"},
+                            },
+                        ],
+                    }
+                ]
+            }
+        }
+    )
+
+    new_publication, _audit_events = modsfixer.audit(publication, [], None, None)
+
+    assert new_publication.contributions[0].affiliations == [
+        {
+            "@type": "Organization",
+            "nameByLang": {"eng": "ROR org in English"},
+            "identifiedBy": [{"@type": "ROR", "value": "https://ror.org/12345"}],
+        },
+        {
+            "@type": "Organization",
+            "nameByLang": {"swe": "ROR-org på svenska"},
+            "identifiedBy": [{"@type": "ROR", "value": "https://ror.org/67890"}],
+        },
+    ]
+
+
+def test_should_merge_kb_se_authority_if_different_languages():
+    publication = Publication(
+        {
+            "instanceOf": {
+                "contribution": [
+                    {
+                        "@type": "Contribution",
+                        "agent": {
+                            "@type": "Person",
+                            "familyName": "Bar",
+                            "givenName": "Foo",
+                        },
+                        "hasAffiliation": [
+                            {
+                                "@type": "Organization",
+                                "identifiedBy": [
+                                    {
+                                        "@type": "URI",
+                                        "source": {"@type": "Source", "code": "kb.se"},
+                                        "value": "example.com",
+                                    }
+                                ],
+                                "nameByLang": {"swe": "authority kb.se, svenska"},
+                            },
+                            {
+                                "@type": "Organization",
+                                "identifiedBy": [
+                                    {
+                                        "@type": "URI",
+                                        "source": {"@type": "Source", "code": "kb.se"},
+                                        "value": "example.com",
+                                    }
+                                ],
+                                "nameByLang": {"eng": "authority kb.se, English"},
+                            },
+                        ],
+                    }
+                ]
+            }
+        }
+    )
+
+    new_publication, _audit_events = modsfixer.audit(publication, [], None, None)
+
+    assert new_publication.contributions[0].affiliations == [
+        {
+            "@type": "Organization",
+            "nameByLang": {
+                "swe": "authority kb.se, svenska",
+                "eng": "authority kb.se, English",
+            },
+            "identifiedBy": [
+                {
+                    "@type": "URI",
+                    "source": {"@type": "Source", "code": "kb.se"},
+                    "value": "example.com",
+                }
+            ],
+        }
+    ]
+
+
+def test_should_not_merge_kb_se_authority_if_same_language():
+    publication = Publication(
+        {
+            "instanceOf": {
+                "contribution": [
+                    {
+                        "@type": "Contribution",
+                        "agent": {
+                            "@type": "Person",
+                            "familyName": "Bar",
+                            "givenName": "Foo",
+                        },
+                        "hasAffiliation": [
+                            {
+                                "@type": "Organization",
+                                "identifiedBy": [
+                                    {
+                                        "@type": "URI",
+                                        "source": {"@type": "Source", "code": "kb.se"},
+                                        "value": "example.com",
+                                    }
+                                ],
+                                "nameByLang": {"swe": "en institution"},
+                            },
+                            {
+                                "@type": "Organization",
+                                "identifiedBy": [
+                                    {
+                                        "@type": "URI",
+                                        "source": {"@type": "Source", "code": "kb.se"},
+                                        "value": "example.com",
+                                    }
+                                ],
+                                "nameByLang": {"swe": "en annan institution"},
+                            },
+                        ],
+                    }
+                ]
+            }
+        }
+    )
+
+    new_publication, _audit_events = modsfixer.audit(publication, [], None, None)
+
+    assert new_publication.contributions[0].affiliations == [
+        {
+            "@type": "Organization",
+            "identifiedBy": [
+                {
+                    "@type": "URI",
+                    "source": {"@type": "Source", "code": "kb.se"},
+                    "value": "example.com",
+                }
+            ],
+            "nameByLang": {"swe": "en institution"},
+        },
+        {
+            "@type": "Organization",
+            "identifiedBy": [
+                {
+                    "@type": "URI",
+                    "source": {"@type": "Source", "code": "kb.se"},
+                    "value": "example.com",
+                }
+            ],
+            "nameByLang": {"swe": "en annan institution"},
+        },
+    ]

--- a/pipeline/tests/converter/test_parser.py
+++ b/pipeline/tests/converter/test_parser.py
@@ -1465,11 +1465,8 @@ def test_affiliation_is_split_up_by_language(parser):
     expected = [
         {
             "@type": "Organization",
-            "name": "Sektion 3",
-            "language": {
-                "@type": "Language",
-                "code": "swe",
-                '@id': 'https://id.kb.se/language/swe'
+            "nameByLang": {
+                "swe": "Sektion 3"
             },
             "identifiedBy": [
                 {
@@ -1484,11 +1481,8 @@ def test_affiliation_is_split_up_by_language(parser):
             "hasAffiliation": [
                 {
                     "@type": "Organization",
-                    "name": "Språk- och litteraturcentrum",
-                    "language": {
-                        "@type": "Language",
-                        "code": "swe",
-                        '@id': 'https://id.kb.se/language/swe'
+                    "nameByLang": {
+                        "swe": "Språk- och litteraturcentrum"
                     },
                     "identifiedBy": [
                         {
@@ -1503,11 +1497,8 @@ def test_affiliation_is_split_up_by_language(parser):
                     "hasAffiliation": [
                         {
                             "@type": "Organization",
-                            "name": "Institutioner",
-                            "language": {
-                                "@type": "Language",
-                                "code": "swe",
-                                '@id': 'https://id.kb.se/language/swe'
+                            "nameByLang": {
+                                "swe": "Institutioner"
                             },
                             "identifiedBy": [
                                 {
@@ -1526,11 +1517,8 @@ def test_affiliation_is_split_up_by_language(parser):
         },
         {
             "@type": "Organization",
-            "name": "Section 3",
-            "language": {
-                "@type": "Language",
-                "code": "eng",
-                '@id': 'https://id.kb.se/language/eng'
+            "nameByLang": {
+                "eng": "Section 3"
             },
             "identifiedBy": [
                 {
@@ -1545,11 +1533,8 @@ def test_affiliation_is_split_up_by_language(parser):
             "hasAffiliation": [
                 {
                     "@type": "Organization",
-                    "name": "Centre for Languages and Literature",
-                    "language": {
-                        "@type": "Language",
-                        "code": "eng",
-                        '@id': 'https://id.kb.se/language/eng'
+                    "nameByLang": {
+                        "eng": "Centre for Languages and Literature"
                     },
                     "identifiedBy": [
                         {
@@ -1564,11 +1549,8 @@ def test_affiliation_is_split_up_by_language(parser):
                     "hasAffiliation": [
                         {
                             "@type": "Organization",
-                            "name": "Departments",
-                            "language": {
-                                "@type": "Language",
-                                "code": "eng",
-                                '@id': 'https://id.kb.se/language/eng'
+                            "nameByLang": {
+                                "eng": "Departments"
                             },
                             "identifiedBy": [
                                 {
@@ -1670,11 +1652,8 @@ def test_affiliation_with_identified_by(parser):
     expected = [
         {
             "@type": "Organization",
-            "name": "Elektronik",
-            "language": {
-                "@id": "https://id.kb.se/language/swe",
-                "@type": "Language",
-                "code": "swe"
+            "nameByLang": {
+                "swe": "Elektronik"
             },
             "identifiedBy": [
                 {
@@ -1689,11 +1668,8 @@ def test_affiliation_with_identified_by(parser):
             "hasAffiliation": [
                 {
                     "@type": "Organization",
-                    "name": "KTH",
-                    "language": {
-                        "@id": "https://id.kb.se/language/swe",
-                        "@type": "Language",
-                        "code": "swe"
+                    "nameByLang": {
+                        "swe": "KTH"
                     },
                     "identifiedBy": [
                         {
@@ -1888,8 +1864,9 @@ def test_affiliation_language_is_extracted(parser):
     assert actual == [
         {
             '@type': 'Organization',
-            'name': 'Affiliation Name',
-            'language': {'@type': 'Language', 'code': 'swe', '@id': 'https://id.kb.se/language/swe'}
+            "nameByLang": {
+                "swe": "Affiliation Name"
+            },
         }
     ]
 
@@ -1986,11 +1963,8 @@ def test_affiliation_non_organizational(parser):
     expected_affiliations = [
         {
             "@type": "Collaboration",
-            "name": "Affiliation Name",
-            "language": {
-                "@type": "Language",
-                "code": "eng",
-                "@id": "https://id.kb.se/language/eng"
+            "nameByLang": {
+                "eng": "Affiliation Name"
             },
             "identifiedBy": [
                 {

--- a/resources/mods_to_xjsonld.xsl
+++ b/resources/mods_to_xjsonld.xsl
@@ -961,14 +961,21 @@
                             <string key="@type">Organization</string>
                         </xsl:otherwise>
                     </xsl:choose>
-                    <string key="name"><xsl:value-of select="$org"/></string>
-                    <xsl:if test="$org/@lang">
-                        <dict key="language">
-                            <string key="@type">Language</string>
-                            <string key="@id">https://id.kb.se/language/<xsl:value-of select="$org/@lang"/></string>
-                            <string key="code"><xsl:value-of select="$org/@lang"/></string>
-                        </dict>
-                    </xsl:if>
+                    <xsl:choose>
+                        <xsl:when test="$org/@lang">
+                            <dict key="nameByLang">
+                                <string>
+                                    <xsl:attribute name="key">
+                                           <xsl:value-of select="$org/@lang"/>
+                                    </xsl:attribute>
+                                    <xsl:value-of select="$org"/>
+                                </string>
+                            </dict>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <string key="name"><xsl:value-of select="$org"/></string>
+                        </xsl:otherwise>
+                    </xsl:choose>
                     <xsl:if test="$org/@valueURI and $org/@authority">
                         <array key="identifiedBy">
                             <xsl:choose>
@@ -982,6 +989,12 @@
                                 <xsl:when test="$org/@authority = 'kb.se/collaboration'">
                                     <xsl:call-template name="identifier">
                                         <xsl:with-param name="type">uri</xsl:with-param>
+                                        <xsl:with-param name="value" select="$org/@valueURI"/>
+                                    </xsl:call-template>
+                                </xsl:when>
+                                <xsl:when test="$org/@authority = 'ROR'">
+                                    <xsl:call-template name="identifier">
+                                        <xsl:with-param name="type">ROR</xsl:with-param>
                                         <xsl:with-param name="value" select="$org/@valueURI"/>
                                     </xsl:call-template>
                                 </xsl:when>
@@ -1398,6 +1411,9 @@
             </xsl:when>
             <xsl:when test="$type = 'grid'">
                 <string key="@type">GRID</string>
+            </xsl:when>
+            <xsl:when test="$type = 'ROR'">
+                <string key="@type">ROR</string>
             </xsl:when>
             <xsl:otherwise>
                 <string key="@type">Local</string>


### PR DESCRIPTION
See discussion on https://jira.kb.se/browse/SWEPUB2-1118

I first tried to solve this in a "nicer" (?!) way in XSLT (using [Muenchian grouping](http://www.jenitennison.com/xslt/grouping/muenchian.html) but while xsltproc didn't complain, lxml gave me obscure internal errors. To preserve sanity I eventually gave up and added another "auditor" instead, to do the "merge affiliations" stuff.

Also changed the legacy sync part to (hopefully) handle the changes (this will have to be tested at a later stage).