### PR TITLE
Keep track of *all* deleted records and handle legacy sync better

### DIFF
--- a/pipeline/harvest.py
+++ b/pipeline/harvest.py
@@ -875,17 +875,6 @@ if __name__ == "__main__":
     diff = round(t1 - t0, 2)
     log.info(f"Phase 6 (generate processing stats) ran for {diff} seconds")
 
-    if environ.get("SWEPUB_LEGACY_SEARCH_DATABASE"):
-        t0 = t1
-        if incremental:
-            legacy_sync(24)
-        else:
-            # If we're doing a full refresh, sync *all* records
-            legacy_sync(-1)
-        t1 = time.time()
-        diff = round(t1 - t0, 2)
-        log.info(f"Phase 7 (legacy search sync) ran for {diff} seconds")
-
     if harvest_cache and not args.purge:
         log.info(f'Sources harvested: {" ".join(harvest_cache["meta"]["sources_succeeded"])}')
         if harvest_cache["meta"]["sources_failed"]:
@@ -906,3 +895,10 @@ if __name__ == "__main__":
                 )
         except Exception as e:
             log.warning(f"Failed saving harvest ID cache to {ID_CACHE_FILE}: {e}")
+
+    if environ.get("SWEPUB_LEGACY_SEARCH_DATABASE"):
+        t0 = t1
+        legacy_sync()
+        t1 = time.time()
+        diff = round(t1 - t0, 2)
+        log.info(f"Phase 7 (legacy search sync) ran for {diff} seconds")

--- a/resources/schema.sql
+++ b/resources/schema.sql
@@ -20,6 +20,15 @@ CREATE TABLE harvest_history (
 CREATE INDEX idx_harvest_history_source ON harvest_history (source);
 
 
+CREATE TABLE legacy_sync_history (
+    id INTEGER PRIMARY KEY,
+    sync_start INTEGER DEFAULT (strftime('%s', 'now')), -- seconds since epoch
+    sync_completed INT,
+    sync_succeeded INT,
+    synced_records INT
+);
+
+
 -- Because Swepub APIs expose publications as originally harvested, these must be kept.
 CREATE TABLE original (
     id INTEGER PRIMARY KEY,


### PR DESCRIPTION
Handles the problem described in https://jira.kb.se/browse/SWEPUB2-1102 by keeping better track of deleted records, and keeping a history of "legacy sync" executions.