### PR TITLE
Convert constituent relatedItem to hasPart Resource

### DIFF
--- a/pipeline/tests/converter/test_parser.py
+++ b/pipeline/tests/converter/test_parser.py
@@ -1294,6 +1294,28 @@ def test_host_relateditem_no_authority(parser):
     assert actual == expected
 
 
+def test_constituent_relateditem(parser):
+    raw_xml = MODS(f"""
+      <relatedItem type="constituent">
+          <identifier type="uri">http://example.org/article/table-1</identifier>
+      </relatedItem>
+    """)
+    expected = [
+        {
+            "@type": "Resource",
+            "identifiedBy": [
+                {
+                    "@type": "URI",
+                    "value": "http://example.org/article/table-1"
+                }
+            ]
+        }
+    ]
+
+    actual = parser.parse_mods(raw_xml)['hasPart']
+    assert actual == expected
+
+
 def test_orcid_person_id_is_extracted(parser):
     raw_xml = MODS("""
       <name type="personal">

--- a/resources/mods_to_xjsonld.xsl
+++ b/resources/mods_to_xjsonld.xsl
@@ -220,6 +220,17 @@
                     </xsl:for-each>
                 </array>
             </xsl:if>
+            <xsl:if test="mods:relatedItem[@type = 'constituent']">
+                <array key="hasPart">
+                    <xsl:for-each select="mods:relatedItem[@type = 'constituent']">
+                        <dict>
+                            <xsl:call-template name="relatedItem">
+                                <xsl:with-param name="relatedItem" select="." />
+                            </xsl:call-template>
+                        </dict>
+                    </xsl:for-each>
+                </array>
+            </xsl:if>
             <xsl:if test="mods:recordInfo">
                 <dict key="meta">
                     <string key="@type">AdminMetadata</string>
@@ -754,6 +765,9 @@
         <xsl:choose>
             <xsl:when test="mods:genre = 'dataset'">
                 <string key="@type">Dataset</string>
+            </xsl:when>
+            <xsl:when test="@type = 'constituent'">
+                <string key="@type">Resource</string>
             </xsl:when>
             <xsl:otherwise>
                 <string key="@type">Work</string>


### PR DESCRIPTION
Adding `hasPart` relation on the instance itself (and not specifying the object type beyond `Resource`).