### PR TITLE
Don't duplicate record_info data when reprocessing a record

### DIFF
--- a/pipeline/harvest.py
+++ b/pipeline/harvest.py
@@ -591,7 +591,7 @@ def _handle_reprocess_affected_records(source):
         for oai_id in oai_ids_to_reprocess:
             try:
                 xml = cursor.execute("SELECT data FROM original WHERE oai_id = ?", [oai_id]).fetchone()["data"]
-                original_converted = cursor.execute("SELECT original_id, source FROM converted WHERE oai_id = ?", [oai_id]).fetchone()
+                original_converted = cursor.execute("SELECT id, original_id, source FROM converted WHERE oai_id = ?", [oai_id]).fetchone()
                 converted = convert(xml)
                 (field_events, record_info) = validate(converted, harvest_cache, session, original_converted["source"], cached_paths, inner_cursor)
                 (audited, audit_events) = audit(converted, harvest_cache, session)
@@ -599,7 +599,7 @@ def _handle_reprocess_affected_records(source):
                 lock.acquire()
                 try:
                     with get_connection() as inner_connection:
-                        store_converted(original_converted["original_id"], audited.body, audit_events.data, field_events, record_info, inner_connection)
+                        store_converted(original_converted["original_id"], audited.body, audit_events.data, field_events, record_info, inner_connection, clear_record_info=True, original_converted_id=original_converted["id"])
                 except Exception:
                         log.warning(traceback.format_exc())
                 finally:

--- a/pipeline/storage.py
+++ b/pipeline/storage.py
@@ -129,9 +129,14 @@ def serialize(obj):
     return obj.__dict__
 
 
-def store_converted(original_rowid, converted, audit_events, field_events, record_info, connection):
+def store_converted(original_rowid, converted, audit_events, field_events, record_info, connection, clear_record_info=False, original_converted_id=None):
     try:
         cur = connection.cursor()
+        # If a we're reprocessing a record, clear its converted_record_info data, otherwise that data
+        # will be duplicated and the processing stats will be wrong
+        if clear_record_info and original_converted_id:
+            cur.execute("DELETE FROM converted_record_info WHERE converted_id = ?", [original_converted_id])
+
         doc = BibframeSource(converted)
         converted_events = {"audit_events": audit_events, "field_events": field_events}
 


### PR DESCRIPTION
In #6 we introduced reprocessing of certain affected records but didn't clear out the `converted_record_info` data that had been added the first time around. Reprocessing means that we repeat the convert/validate/audit steps, and these records would then get duplicated data in `converted_record_info`, so the processing stats would be slightly wrong. This change ensures we clear out that data before reprocessing.

https://kbse.atlassian.net/browse/SWEPUB2-1075