### PR TITLE
Optionally preserve harvest history from previous database

### DIFF
--- a/pipeline/harvest.py
+++ b/pipeline/harvest.py
@@ -634,6 +634,11 @@ def handle_args():
         help="Forcibly creates a new database, removing the existing one if one exists as the given path",
     )
     group.add_argument(
+        "--force-new-but-keep-history",
+        action="store_true",
+        help="Forcibly creates a new database, but, if an old database is detected, copies the contents of its `harvest_history` and `rejected` tables",
+    )
+    group.add_argument(
         "-u",
         "--update",
         action="store_true",
@@ -811,7 +816,12 @@ if __name__ == "__main__":
                 for table in TABLES_DELETED_ON_INCREMENTAL_OR_PURGE:
                     cursor.execute(f"DELETE FROM {table}")
         else:
-            clean_and_init_storage()
+            if args.force_new_but_keep_history:
+                log.info("Creating a new db; will preserve harvest history from previous db if found")
+                clean_and_init_storage(preserve_history=True)
+            else:
+                log.info("Creating a new db; will *not* preserve harvest history from previous database if found")
+                clean_and_init_storage()
 
         # Initially synchronization was left up to sqlite3's file locking to handle,
         # which was fine, except that the try/sleep is somewhat inefficient and risks

--- a/pipeline/storage.py
+++ b/pipeline/storage.py
@@ -49,12 +49,7 @@ def copy_history_to_tmp_db():
     src_sqlite_path = get_sqlite_path()
     sqlite_history_tmp_path = get_sqlite_tmp_history_path()
     # If there are old history tmp files, get rid of them
-    if os.path.exists(sqlite_history_tmp_path):
-        os.remove(sqlite_history_tmp_path)
-    if os.path.exists(f"{sqlite_history_tmp_path}-wal"):
-        os.remove(f"{sqlite_history_tmp_path}-wal")
-    if os.path.exists(f"{sqlite_history_tmp_path}-shm"):
-        os.remove(f"{sqlite_history_tmp_path}-shm")
+    remove_sqlite_files(sqlite_history_tmp_path)
 
     con = sqlite3.connect(sqlite_history_tmp_path)
     cur = con.cursor()

--- a/pipeline/storage.py
+++ b/pipeline/storage.py
@@ -86,9 +86,8 @@ def clean_and_init_storage(preserve_history=False):
 
     if preserve_history:
         log.info("Copying history from tmp db to the new db")
-        sqlite_history_tmp_path = get_sqlite_tmp_history_path()
         # Attach temp db with history, copy records
-        cur.execute(f"ATTACH DATABASE '{sqlite_history_tmp_path}' AS history_src")
+        cur.execute(f"ATTACH DATABASE '{get_sqlite_tmp_history_path()}' AS history_src")
         cur.execute("INSERT INTO harvest_history SELECT * FROM history_src.harvest_history")
         cur.execute("INSERT INTO rejected SELECT * FROM history_src.rejected")
         con.commit()


### PR DESCRIPTION
For example:
```
$ python3 -m pipeline.harvest -f uniarts
...

$ sqlite3 swepub.sqlite3 'select id, harvest_start, successes from harvest_history'
id                                    harvest_start                     successes
------------------------------------  --------------------------------  ---------
fe9cc51e-6429-4b6a-86e4-19290aafc6e7  2024-07-23T13:34:54.529014+00:00  513

$ python3 -m pipeline.harvest --force-new-but-keep-history uniarts
...

$ sqlite3 swepub.sqlite3 'select id, harvest_start, successes from harvest_history'
id                                    harvest_start                     successes
------------------------------------  --------------------------------  ---------
fe9cc51e-6429-4b6a-86e4-19290aafc6e7  2024-07-23T13:34:54.529014+00:00  513
e293334f-d668-4522-9040-8a84a4d98cce  2024-07-23T13:36:58.276602+00:00  513
```
https://kbse.atlassian.net/browse/SWEPUB2-1132