### PR TITLE
Switch to SSIF 2025 classifications

### DIFF
--- a/misc/export_tsv_annif.py
+++ b/misc/export_tsv_annif.py
@@ -33,7 +33,8 @@ def dump_tsv(target_language="en", number_of_records=10000, min_level=1, max_lev
                 # Temporary special handling to make it possible to use old
                 # DB dump. Rewrites id.kb.se SSIF classifications to the
                 # new SSIF scheme/base. Also maps converts SSIF 2011->2025;
-                # duplicated from legacy_ssif.py.
+                # duplicated from legacy_ssif.py. To be removed once we have
+                # SSIF 2025 terms in prod.
                 classifications = publication.classifications
                 for classification in classifications:
                     if classification.get("inScheme", {}).get("@id") == OLD_SSIF_SCHEME:

--- a/misc/export_tsv_annif.py
+++ b/misc/export_tsv_annif.py
@@ -5,8 +5,11 @@ from simplemma.langdetect import lang_detector
 
 from pipeline.storage import get_connection, dict_factory
 from pipeline.publication import Publication
-from pipeline.util import get_title_by_language, get_summary_by_language, SSIF_BASE
+from pipeline.util import get_title_by_language, get_summary_by_language, SSIF_SCHEME, SSIF_BASE
+from pipeline.ldcache import get_description
 
+OLD_SSIF_SCHEME = "https://id.kb.se/term/ssif"
+OLD_SSIF_BASE = f"{OLD_SSIF_SCHEME}/"
 
 def dump_tsv(target_language="en", number_of_records=10000, min_level=1, max_level=5):
     limit_sql = ""
@@ -26,6 +29,38 @@ def dump_tsv(target_language="en", number_of_records=10000, min_level=1, max_lev
             if row.get("data"):
                 finalized = orjson.loads(row["data"])
                 publication = Publication(finalized)
+
+                # Temporary special handling to make it possible to use old
+                # DB dump. Rewrites id.kb.se SSIF classifications to the
+                # new SSIF scheme/base. Also maps converts SSIF 2011->2025;
+                # duplicated from legacy_ssif.py.
+                classifications = publication.classifications
+                for classification in classifications:
+                    if classification.get("inScheme", {}).get("@id") == OLD_SSIF_SCHEME:
+                        classification["inScheme"]["@id"] = SSIF_SCHEME
+                        classification["@id"] = classification["@id"].replace(OLD_SSIF_BASE, SSIF_BASE)
+
+                    description = get_description(classification["@id"])
+                    if not description:
+                        continue
+                    is_replaced_bys = description.get("isReplacedBy", [])
+                    if is_replaced_bys:
+                        if len(is_replaced_bys) == 1:
+                            # If there's exactly one possible replacement, use it
+                            classification["@id"] = is_replaced_bys[0]["@id"]
+                        else:
+                            replaced_by_ids = list(map(lambda x: x["@id"].removeprefix(SSIF_BASE), is_replaced_bys))
+                            level_3 = replaced_by_ids[0][:3]
+                            if all(classification.startswith(level_3) for classification in replaced_by_ids):
+                                # All SSIF codes have the same level 3, so use it
+                                classification["@id"] = f"{SSIF_BASE}{level_3}"
+                            else:
+                                narrow_match = description.get("narrowMatch", [])
+                                if len(narrow_match) == 1:
+                                    classification["@id"] = narrow_match[0]["@id"]
+                                else:
+                                    print("No SSIF 2011->2025 mapping possible")
+                publication.classifications = classifications
 
                 # Get SSIF codes, filtered by min/max level, and skip records with
                 # no classification in the desired levels. For example, with

--- a/misc/export_tsv_annif.py
+++ b/misc/export_tsv_annif.py
@@ -5,7 +5,7 @@ from simplemma.langdetect import lang_detector
 
 from pipeline.storage import get_connection, dict_factory
 from pipeline.publication import Publication
-from pipeline.util import get_title_by_language, get_summary_by_language
+from pipeline.util import get_title_by_language, get_summary_by_language, SSIF_BASE
 
 
 def dump_tsv(target_language="en", number_of_records=10000, min_level=1, max_level=5):
@@ -78,7 +78,7 @@ def dump_tsv(target_language="en", number_of_records=10000, min_level=1, max_lev
                         expanded_ssif.add(ssif[:1])
                         expanded_ssif.add(ssif[:3])
                 ssif_str = " ".join(
-                    [f"<https://id.kb.se/term/ssif/{s}>" for s in expanded_ssif]
+                    [f"<{SSIF_BASE}{s}>" for s in expanded_ssif]
                 )
 
                 # Get non-SSIF keywords in the target language

--- a/pipeline/audit.py
+++ b/pipeline/audit.py
@@ -6,6 +6,7 @@ from pipeline.auditors.creatorcount import CreatorCountAuditor
 from pipeline.auditors.ssif import SSIFAuditor
 from pipeline.auditors.contributor import ContributorAuditor
 from pipeline.auditors.issn import ISSNAuditor
+from pipeline.auditors.legacy_ssif import LegacySSIFAuditor
 from pipeline.auditors.subjects import SubjectsAuditor
 from pipeline.auditors.oa import OAAuditor
 from pipeline.auditors.autoclassifier import AutoclassifierAuditor
@@ -19,6 +20,7 @@ AUDITORS = [
     ContributorAuditor(),
     SSIFAuditor(),
     ISSNAuditor(),
+    LegacySSIFAuditor(),
     SubjectsAuditor(),
     OAAuditor(),
     AutoclassifierAuditor(),

--- a/pipeline/auditors/autoclassifier.py
+++ b/pipeline/auditors/autoclassifier.py
@@ -31,7 +31,7 @@ def _eligible_for_autoclassification(publication):
 
 
 def _create_classification(code):
-    classification = get_description(f"https://id.kb.se/term/ssif/{code}").copy()
+    classification = get_description(f"{SSIF_BASE}{code}").copy()
     classification["@annotation"] = {
         "assigner": {"@id": SWEPUB_CLASSIFIER_ID}
     }

--- a/pipeline/auditors/legacy_ssif.py
+++ b/pipeline/auditors/legacy_ssif.py
@@ -3,7 +3,7 @@ from pipeline.util import SSIF_BASE
 from pipeline.ldcache import get_description
 
 class LegacySSIFAuditor(BaseAuditor):
-    """Used to flag use of legacy SSIF codes, and migrate classifications to SSIF 2025 when possible"""
+    """Used to migrate classifications to SSIF 2025 when possible"""
 
     def __init__(self):
         self.name = LegacySSIFAuditor.__name__
@@ -25,9 +25,5 @@ class LegacySSIFAuditor(BaseAuditor):
                         classification["@id"] = narrow_match[0]["@id"]
                     elif (close_match := description.get("closeMatch", [])) and len(close_match) == 1:
                         classification["@id"] = close_match[0]["@id"]
-                    else:
-                        ssifs_not_migrated.add(classification["@id"])
-        if ssifs_not_migrated:
-            audit_events.add_event(self.name, "SSIF_2011_not_migrated", '', list(ssifs_not_migrated), '')
 
         return publication, audit_events

--- a/pipeline/auditors/legacy_ssif.py
+++ b/pipeline/auditors/legacy_ssif.py
@@ -9,29 +9,25 @@ class LegacySSIFAuditor(BaseAuditor):
         self.name = LegacySSIFAuditor.__name__
 
     def audit(self, publication, audit_events, _harvest_cache, _session):
-        #old_classifications = publication.classifications
-
+        ssifs_not_migrated = set()
         for classification in publication.classifications:
-            description = get_description(classification["@id"])
-            if not description:
+            if not (description := get_description(classification["@id"])):
                 continue
-            is_replaced_bys = description.get("isReplacedBy", [])
-            if is_replaced_bys:
+            if is_replaced_bys := description.get("isReplacedBy", []):
                 if len(is_replaced_bys) == 1:
-                    # If there's exactly one possible replacement, use it
                     classification["@id"] = is_replaced_bys[0]["@id"]
                 else:
                     replaced_by_ids = list(map(lambda x: x["@id"].removeprefix(SSIF_BASE), is_replaced_bys))
                     level_3 = replaced_by_ids[0][:3]
                     if all(classification.startswith(level_3) for classification in replaced_by_ids):
-                        # All SSIF codes have the same level 3, so use it
                         classification["@id"] = f"{SSIF_BASE}{level_3}"
+                    elif (narrow_match := description.get("narrowMatch", [])) and len(narrow_match) == 1:
+                        classification["@id"] = narrow_match[0]["@id"]
+                    elif (close_match := description.get("closeMatch", [])) and len(close_match) == 1:
+                        classification["@id"] = close_match[0]["@id"]
                     else:
-                        narrow_match = description.get("narrowMatch", [])
-                        if len(narrow_match) == 1:
-                            classification["@id"] = narrow_match[0]["@id"]
-                        else:
-                            print("No SSIF 2011->2025 mapping possible")
-                            audit_events.add_event(self.name, "SSIF_2011_not_migrated", '', publication.classifications, '')
+                        ssifs_not_migrated.add(classification["@id"])
+        if ssifs_not_migrated:
+            audit_events.add_event(self.name, "SSIF_2011_not_migrated", '', list(ssifs_not_migrated), '')
 
         return publication, audit_events

--- a/pipeline/auditors/legacy_ssif.py
+++ b/pipeline/auditors/legacy_ssif.py
@@ -32,6 +32,6 @@ class LegacySSIFAuditor(BaseAuditor):
                             classification["@id"] = narrow_match[0]["@id"]
                         else:
                             print("No SSIF 2011->2025 mapping possible")
-                            audit_events.add_event(self.name, "SSIF_2011_not_migrated", has_legacy_ssif, publication.classifications, '')
+                            audit_events.add_event(self.name, "SSIF_2011_not_migrated", '', publication.classifications, '')
 
         return publication, audit_events

--- a/pipeline/auditors/legacy_ssif.py
+++ b/pipeline/auditors/legacy_ssif.py
@@ -1,0 +1,36 @@
+from pipeline.auditors import BaseAuditor
+from pipeline.util import SSIF_BASE
+from pipeline.ldcache import get_description
+
+class LegacySSIFAuditor(BaseAuditor):
+    """Used to flag use of legacy SSIF codes, and migrate classifications to SSIF 2025 when possible"""
+
+    def __init__(self):
+        self.name = LegacySSIFAuditor.__name__
+
+    def audit(self, publication, audit_events, _harvest_cache, _session):
+        has_legacy_ssif = False
+
+        for classification in publication.classifications:
+            description = get_description(classification["@id"])
+            if not description:
+                continue
+            is_replaced_bys = description.get("isReplacedBy", [])
+            if is_replaced_bys:
+                has_legacy_ssif = True
+                if len(is_replaced_bys) == 1:
+                    # If there's exactly one possible replacement, use it
+                    classification["@id"] = is_replaced_bys[0]["@id"]
+                else:
+                    replaced_by_ids = list(map(lambda x: x["@id"].removeprefix(SSIF_BASE), is_replaced_bys))
+                    level_3 = replaced_by_ids[0][:3]
+                    if all(classification.startswith(level_3) for classification in replaced_by_ids):
+                        # All SSIF codes have the same level 3, so use it
+                        classification["@id"] = f"{SSIF_BASE}{level_3}"
+                    else:
+                        # The level 3 codes differ. Special handling?
+                        continue
+
+        audit_events.add_event(self.name, "has_legacy_SSIF", has_legacy_ssif)
+
+        return publication, audit_events

--- a/pipeline/legacy_publication.py
+++ b/pipeline/legacy_publication.py
@@ -1,5 +1,6 @@
 import dateutil.parser
 from datetime import datetime
+from pipeline.util import SSIF_SCHEME
 
 genre_form_publication_mappings = {
     "https://id.kb.se/term/swepub/output/publication/editorial-letter": ["art"],
@@ -715,7 +716,7 @@ def _get_provision_activity_statement(body):
 
 
 def is_ssif_classification(term):
-    return term.get("inScheme", {}).get("@id", "").startswith(("https://id.kb.se/term/ssif", "https://id.kb.se/term/uka"))
+    return term.get("inScheme", {}).get("@id", "").startswith(("https://id.kb.se/term/ssif", "https://id.kb.se/term/uka", SSIF_SCHEME))
 
 
 def _format_date_as_year(date):

--- a/pipeline/tests/converter/test_parser.py
+++ b/pipeline/tests/converter/test_parser.py
@@ -1,6 +1,7 @@
 import re
 import pytest
 from lxml.etree import LxmlError, XMLSyntaxError
+from pipeline.util import SSIF_SCHEME, SSIF_BASE
 
 MODS = """
     <record xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -300,11 +301,11 @@ def test_parser(parser):
             ],
             "classification": [
                 {
-                    "@id": "https://id.kb.se/term/ssif/30220",
+                    "@id": f"{SSIF_BASE}30220",
                     "@type": "Classification",
                     "code": "30220",
                     "prefLabelByLang": {"en": "Obstetrics, Gynecology and Reproductive Medicine"},
-                    "inScheme": {"@id": "https://id.kb.se/term/ssif", "@type": "ConceptScheme"},
+                    "inScheme": {"@id": SSIF_SCHEME, "@type": "ConceptScheme"},
                     #"broader": {
                     #    "prefLabel": "Clinical Medicine",
                     #    "broader": {
@@ -313,11 +314,11 @@ def test_parser(parser):
                     #}
                 },
                 {
-                    "@id": "https://id.kb.se/term/ssif/30305",
+                    "@id": f"{SSIF_BASE}30305",
                     "@type": "Classification",
                     "code": "30305",
                     "prefLabelByLang": {"en": "Nursing"},
-                    "inScheme": {"@id": "https://id.kb.se/term/ssif", "@type": "ConceptScheme"},
+                    "inScheme": {"@id": SSIF_SCHEME, "@type": "ConceptScheme"},
                 }
             ],
             "hasNote": [
@@ -2274,17 +2275,17 @@ def test_uka_subjects_with_href(parser):
       """)
     expected = [
         {
-            "@id": "https://id.kb.se/term/ssif/60203",
+            "@id": f"{SSIF_BASE}60203",
             '@type': 'Classification',
             'code': '60203',
-            "inScheme": {"@id": "https://id.kb.se/term/ssif", "@type": "ConceptScheme"},
+            "inScheme": {"@id": SSIF_SCHEME, "@type": "ConceptScheme"},
             "prefLabelByLang": {"sv": "Litteraturvetenskap"},
         },
         {
-            "@id": "https://id.kb.se/term/ssif/60203",
+            "@id": f"{SSIF_BASE}60203",
             '@type': 'Classification',
             'code': '60203',
-            "inScheme": {"@id": "https://id.kb.se/term/ssif", "@type": "ConceptScheme"},
+            "inScheme": {"@id": SSIF_SCHEME, "@type": "ConceptScheme"},
             "prefLabelByLang": {"en": "Literature"},
         },
     ]
@@ -2307,24 +2308,24 @@ def test_uka_subject_once_per_level(parser):
       """)
     expected = [
         {
-            "@id": "https://id.kb.se/term/ssif/6",
+            "@id": f"{SSIF_BASE}6",
             '@type': 'Classification',
             'code': '6',
-            "inScheme": {"@id": "https://id.kb.se/term/ssif", "@type": "ConceptScheme"},
+            "inScheme": {"@id": SSIF_SCHEME, "@type": "ConceptScheme"},
             "prefLabelByLang": {"sv": "Humaniora"},
         },
         {
-            "@id": "https://id.kb.se/term/ssif/602",
+            "@id": f"{SSIF_BASE}602",
             '@type': 'Classification',
             'code': '602',
-            "inScheme": {"@id": "https://id.kb.se/term/ssif", "@type": "ConceptScheme"},
+            "inScheme": {"@id": SSIF_SCHEME, "@type": "ConceptScheme"},
             "prefLabelByLang": {"sv": "Spr\u00e5k och litteratur"},
         },
         {
-            "@id": "https://id.kb.se/term/ssif/60203",
+            "@id": f"{SSIF_BASE}60203",
             '@type': 'Classification',
             'code': '60203',
-            "inScheme": {"@id": "https://id.kb.se/term/ssif", "@type": "ConceptScheme"},
+            "inScheme": {"@id": SSIF_SCHEME, "@type": "ConceptScheme"},
             "prefLabelByLang": {"sv": "Litteraturvetenskap"},
         },
     ]
@@ -2486,7 +2487,7 @@ def test_ssif_classification(parser):
             '@annotation': {
                 'assigner': {'@type': 'SoftwareAgent', 'label': 'GPT-4'}
             },
-            '@id': 'https://id.kb.se/term/ssif/60203',
+            '@id': f"{SSIF_BASE}60203",
         }
     ]
     actual = parser.parse_mods(raw_xml)['instanceOf']['classification']

--- a/pipeline/tests/deduplicator/test_merger.py
+++ b/pipeline/tests/deduplicator/test_merger.py
@@ -6,7 +6,7 @@ from pipeline.publication import Publication
 from pipeline.publication import Contribution
 from pipeline.publication import IsPartOf
 
-from pipeline.util import SWEPUB_CLASSIFIER_ID
+from pipeline.util import SWEPUB_CLASSIFIER_ID, SSIF_BASE
 
 from flexmock import flexmock
 
@@ -208,12 +208,12 @@ def test_merge_classifications():
         "instanceOf": {
             "classification": [
                 {
-                    "@id": "https://id.kb.se/term/ssif/10606",
+                    "@id": f"{SSIF_BASE}10606",
                     "@type": "Classification",
                     "prefLabelByLang": {"en": "Microbiology", "sv": "Mikrobiologi"}
                 },
                 {
-                    "@id": "https://id.kb.se/term/ssif/10203",
+                    "@id": f"{SSIF_BASE}10203",
                     "@type": "Classification",
                     "prefLabelByLang": {"en": "Bioinformatics", "sv": "Bioinformatik"}
                 }
@@ -225,12 +225,12 @@ def test_merge_classifications():
         "instanceOf": {
             "classification": [
                 {
-                    "@id": "https://id.kb.se/term/ssif/10606",
+                    "@id": f"{SSIF_BASE}10606",
                     "@type": "Classification",
                     "prefLabelByLang": {"en": "Microbiology", "sv": "Mikrobiologi"}
                 },
                 {
-                    "@id": "https://id.kb.se/term/ssif/30102",
+                    "@id": f"{SSIF_BASE}30102",
                     "@type": "Classification",
                     "prefLabelByLang": {"en": "Pharmacology and Toxicology", "sv": "Farmakologi och toxikologi"}
                 }
@@ -244,17 +244,17 @@ def test_merge_classifications():
 
     assert merged_master.classifications == [
         {
-            "@id": "https://id.kb.se/term/ssif/10606",
+            "@id": f"{SSIF_BASE}10606",
             "@type": "Classification",
             "prefLabelByLang": {"en": "Microbiology", "sv": "Mikrobiologi"}
         },
         {
-            "@id": "https://id.kb.se/term/ssif/10203",
+            "@id": f"{SSIF_BASE}10203",
             "@type": "Classification",
             "prefLabelByLang": {"en": "Bioinformatics", "sv": "Bioinformatik"}
         },
         {
-            "@id": "https://id.kb.se/term/ssif/30102",
+            "@id": f"{SSIF_BASE}30102",
             "@type": "Classification",
             "prefLabelByLang": {"en": "Pharmacology and Toxicology", "sv": "Farmakologi och toxikologi"}
         }
@@ -265,12 +265,12 @@ def test_merge_classifications_with_autoclassified_subject():
         "instanceOf": {
             "classification": [
                 {
-                    "@id": "https://id.kb.se/term/ssif/10606",
+                    "@id": f"{SSIF_BASE}10606",
                     "@type": "Classification",
                     "prefLabelByLang": {"en": "Microbiology", "sv": "Mikrobiologi"}
                 },
                 {
-                    "@id": "https://id.kb.se/term/ssif/10203",
+                    "@id": f"{SSIF_BASE}10203",
                     "@type": "Classification",
                     "prefLabelByLang": {"en": "Bioinformatics", "sv": "Bioinformatik"}
                 }
@@ -284,13 +284,13 @@ def test_merge_classifications_with_autoclassified_subject():
         "instanceOf": {
             "classification": [
                 {
-                    "@id": "https://id.kb.se/term/ssif/30105",
+                    "@id": f"{SSIF_BASE}30105",
                     "@type": "Classification",
                     "prefLabelByLang": {"en": "Neurosciences", "sv": "Neurovetenskaper"},
                     "@annotation": {"assigner": {"@id": SWEPUB_CLASSIFIER_ID}}
                 },
                 {
-                    "@id": "https://id.kb.se/term/ssif/30102",
+                    "@id": f"{SSIF_BASE}30102",
                     "@type": "Classification",
                     "prefLabelByLang": {"en": "Pharmacology and Toxicology", "sv": "Farmakologi och toxikologi"}
                 }
@@ -304,17 +304,17 @@ def test_merge_classifications_with_autoclassified_subject():
 
     assert merged_master.classifications == [
         {
-            "@id": "https://id.kb.se/term/ssif/10606",
+            "@id": f"{SSIF_BASE}10606",
             "@type": "Classification",
             "prefLabelByLang": {"en": "Microbiology", "sv": "Mikrobiologi"}
         },
         {
-            "@id": "https://id.kb.se/term/ssif/10203",
+            "@id": f"{SSIF_BASE}10203",
             "@type": "Classification",
             "prefLabelByLang": {"en": "Bioinformatics", "sv": "Bioinformatik"}
         },
         {
-            "@id": "https://id.kb.se/term/ssif/30102",
+            "@id": f"{SSIF_BASE}30102",
             "@type": "Classification",
             "prefLabelByLang": {"en": "Pharmacology and Toxicology", "sv": "Farmakologi och toxikologi"}
         }

--- a/pipeline/util.py
+++ b/pipeline/util.py
@@ -1,4 +1,5 @@
 from aenum import Enum
+from pathlib import Path
 
 from difflib import SequenceMatcher
 from jsonpath_rw import parse
@@ -10,6 +11,7 @@ from unidecode import unidecode
 
 from requests.adapters import Retry
 from random import random
+from lxml import etree
 
 from pipeline.swepublog import logger as log
 
@@ -39,7 +41,7 @@ ENRICHING_AUDITORS_CODES = [
 
 SWEPUB_CLASSIFIER_ID = "https://id.kb.se/generator/swepub-classifier"
 
-SSIF_SCHEME = 'https://id.kb.se/term/ssif'
+SSIF_SCHEME = etree.parse(Path(__file__).parent / "../resources/ssif_scheme.xml").getroot().text
 SSIF_BASE = f'{SSIF_SCHEME}/'
 
 

--- a/pipeline/validate.py
+++ b/pipeline/validate.py
@@ -6,7 +6,7 @@ from os import path
 
 from pipeline.normalize import *
 
-from pipeline.util import get_at_path, remove_at_path, FieldMeta, Enrichment, Validation, Normalization
+from pipeline.util import get_at_path, remove_at_path, FieldMeta, Enrichment, Validation, Normalization, SSIF_SCHEME
 
 from pipeline.validators.datetime import validate_date_time
 from pipeline.validators.doi import validate_doi
@@ -59,7 +59,7 @@ PATHS = {
         'instanceOf.subject[?(@.@type=="Topic")].prefLabel',
         'instanceOf.hasNote[?(@.@type=="Note")].label',
     ),
-    "SSIF": ('instanceOf.classification[?(@.inScheme.@id=="https://id.kb.se/term/ssif")].code',),
+    "SSIF": (f"instanceOf.classification[?(@.inScheme.@id==\"{SSIF_SCHEME}\")].code",),
 }
 
 PRECOMPILED_PATHS = {k: [parse(p) for p in v] for k, v in PATHS.items()}

--- a/pipeline/validate.py
+++ b/pipeline/validate.py
@@ -59,7 +59,7 @@ PATHS = {
         'instanceOf.subject[?(@.@type=="Topic")].prefLabel',
         'instanceOf.hasNote[?(@.@type=="Note")].label',
     ),
-    "SSIF": (f"instanceOf.classification[?(@.inScheme.@id==\"{SSIF_SCHEME}\")].code",),
+    "SSIF": (f"instanceOf.classification[*].@id",),
 }
 
 PRECOMPILED_PATHS = {k: [parse(p) for p in v] for k, v in PATHS.items()}

--- a/pipeline/validate.py
+++ b/pipeline/validate.py
@@ -131,8 +131,10 @@ def validate_stuff(field_events, session, harvest_cache, body, source, cached_pa
                     validate_date_time(field)
                 if field.id_type == "creator_count":
                     validate_creator_count(field)
-                if field.id_type == "SSIF":
-                    validate_ssif(field)
+                # SSIF is not enriched, so don't validate it twice.
+                if field.validation_status == Validation.PENDING:
+                    if field.id_type == "SSIF":
+                        validate_ssif(field)
                 if field.id_type == "free_text":
                     field.validation_status = Validation.VALID  # formerly "AcceptingValidator"
 

--- a/pipeline/validators/ssif.py
+++ b/pipeline/validators/ssif.py
@@ -14,10 +14,17 @@ def validate_ssif(field):
         )
         field.validation_status = Validation.INVALID
         return False
-    field.events.append(
-        make_event(event_type="validation", code="format", result="valid", value=ssif)
-    )
-    field.validation_status = Validation.VALID
+    # Temporary handling for the one SSIF 2011 code we can't map to SSIF 2025
+    if ssif == "21101":
+        field.events.append(
+            make_event(event_type="validation", code="legacy", result="invalid", value=ssif)
+        )
+        field.validation_status = Validation.INVALID
+    else:
+        field.events.append(
+            make_event(event_type="validation", code="format", result="valid", value=ssif)
+        )
+        field.validation_status = Validation.VALID
     if not field.is_enriched():
         field.enrichment_status = Enrichment.UNCHANGED
     return True

--- a/pipeline/validators/ssif.py
+++ b/pipeline/validators/ssif.py
@@ -1,11 +1,11 @@
 import re
-from pipeline.util import make_event, Validation, Enrichment
+from pipeline.util import make_event, Validation, Enrichment, SSIF_BASE
 
 ssif_regexp = re.compile("^[0-9]$|^[0-9]{3}$|^[0-9]{5}$")
 
 
 def validate_ssif(field):
-    ssif = field.value
+    ssif = field.value.removeprefix(SSIF_BASE)
 
     hit = ssif_regexp.fullmatch(ssif)
     if hit is None:

--- a/resources/mods_to_xjsonld.xsl
+++ b/resources/mods_to_xjsonld.xsl
@@ -11,6 +11,7 @@
 
     <xsl:output indent="yes" encoding="UTF-8"/>
 
+    <xsl:variable name="ssif_scheme" select="document('ssif_scheme.xml')/value" />
     <xsl:variable name="langmap" select="document('langmap.xml')/langmap/lang"/>
 
     <xsl:template match="/">
@@ -1308,7 +1309,8 @@
         <xsl:for-each select="mods:subject[@authority = 'uka.se' and @xlink:href]">
             <dict>
                 <string key="@id">
-                    <xsl:text>https://id.kb.se/term/ssif/</xsl:text>
+                    <xsl:value-of select="$ssif_scheme" />
+                    <xsl:text>/</xsl:text>
                     <xsl:value-of select="@xlink:href"/>
                 </string>
                 <string key="@type">Classification</string>
@@ -1328,7 +1330,7 @@
                 </xsl:choose>
                 <dict key="inScheme">
                     <string key="@type">ConceptScheme</string>
-                    <string key="@id">https://id.kb.se/term/ssif</string>
+                    <string key="@id"><xsl:value-of select="$ssif_scheme" /></string>
                 </dict>
             </dict>
         </xsl:for-each>
@@ -1390,7 +1392,8 @@
             <xsl:choose>
                 <xsl:when test="@authority = 'ssif'">
                     <string key="@id">
-                        <xsl:text>https://id.kb.se/term/ssif/</xsl:text>
+                        <xsl:value-of select="$ssif_scheme" />
+                        <xsl:text>/</xsl:text>
                         <xsl:choose>
                             <xsl:when test="@xlink:href">
                                 <xsl:value-of select="@xlink:href"/>

--- a/resources/ssif.jsonld
+++ b/resources/ssif.jsonld
@@ -12,6 +12,18 @@
     "commentByLang": {
       "@id": "comment",
       "@container": "@language"
+    },
+    "hiddenLabelByLang": {
+      "@id": "hiddenLabel",
+      "@container": "@language"
+    },
+    "scopeNoteByLang": {
+      "@id": "scopeNote",
+      "@container": "@language"
+    },
+    "historyNoteByLang": {
+      "@id": "historyNote",
+      "@container": "@language"
     }
   },
   "@graph": [
@@ -22,7 +34,7 @@
       "code": "1",
       "prefLabelByLang": {
         "sv": "Naturvetenskap",
-        "en": "Natural Sciences"
+        "en": "Natural sciences"
       }
     },
     {
@@ -32,7 +44,7 @@
       "code": "101",
       "prefLabelByLang": {
         "sv": "Matematik",
-        "en": "Mathematics"
+        "en": "Mathematical sciences"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/1"}
     },
@@ -100,7 +112,13 @@
         "sv": "Sannolikhetsteori och statistik",
         "en": "Probability Theory and Statistics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/101"}
+      "commentByLang": {
+        "sv": "Statistik med medicinska aspekter under 30118 och samhällsvetenskapliga aspekter under 50907",
+        "en": "Statistics with medical aspects at 30118 and with social aspects at 50907"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/101"},
+      "scopeNoteByLang": {"sv": "Annan"},
+      "historyNoteByLang": {"sv": "Numera finns även ämnena medicinsk biostatistik 30118 (SSIF2025) som ingår i Medicinska och farmaceutiska grundvetenskaper 301 och Statistik inom samhällsvetenskap 50907 (SSIF2025) som ingår i Annan samhällsvetenskap 509."}
     },
     {
       "@id": "https://id.kb.se/term/ssif/10199",
@@ -147,8 +165,8 @@
         "en": "Information Systems"
       },
       "commentByLang": {
-        "sv": "samhällsvetenskaplig inriktning under 50804",
-        "en": "Social aspects to be 50804"
+        "sv": "samhällsvetenskapliga aspekter under 50804",
+        "en": "Social aspects at 50804"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/102"}
     },
@@ -167,7 +185,7 @@
       },
       "commentByLang": {
         "sv": "tillämpningar under 10610",
-        "en": "applications to be 10610"
+        "en": "Applications at 10610"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/102"}
     },
@@ -182,8 +200,8 @@
       },
       "altLabelByLang": {"sv": "interaktionsdesign"},
       "commentByLang": {
-        "sv": "Samhällsvetenskapliga aspekter under 50803",
-        "en": "Social aspects to be 50803"
+        "sv": "Samhällsvetenskapliga aspekter under 50804",
+        "en": "Social aspects at 50804"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/102"}
     },
@@ -215,14 +233,16 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "10207",
       "prefLabelByLang": {
-        "sv": "Datorseende och robotik",
-        "en": "Computer Vision and Robotics"
+        "sv": "Datorgrafik och datorseende",
+        "en": "Computer graphics and computer vision"
       },
-      "altLabelByLang": {
-        "sv": "autonoma system",
-        "en": "Autonomous Systems"
+      "commentByLang": {
+        "sv": "systemtekniska aspekter under 20208",
+        "en": "System engineering aspects at 20208"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/102"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/102"},
+      "hiddenLabelByLang": {"sv": "Datorseende och robotik (autonoma system)"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/10208",
@@ -230,25 +250,82 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "10208",
       "prefLabelByLang": {
-        "sv": "Språkteknologi",
-        "en": "Language Technology"
+        "sv": "Språkbehandling och datorlingvistik",
+        "en": "Natural Language Processing"
       },
-      "altLabelByLang": {
-        "sv": "språkvetenskaplig databehandling",
-        "en": "Computational Linguistics"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/102"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/102"},
+      "hiddenLabelByLang": {"sv": "Språkteknologi (språkvetenskaplig databehandling)"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/10209",
       "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "10209",
+      "hiddenLabel": "Medieteknik",
+      "isReplacedBy": [
+        {"@id": "https://id.kb.se/term/ssif/10202"},
+        {"@id": "https://id.kb.se/term/ssif/10204"}
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/10210",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "10210",
       "prefLabelByLang": {
-        "sv": "Medieteknik",
-        "en": "Media and Communication Technology"
+        "sv": "Artificiell intelligens",
+        "en": "Artificial Intelligence"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/102"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/102"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/10211",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "10211",
+      "prefLabelByLang": {
+        "sv": "Säkerhet, integritet och kryptologi",
+        "en": "Security, Privacy and Cryptography"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/102"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/10212",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "10212",
+      "prefLabelByLang": {
+        "sv": "Algoritmer",
+        "en": "Algorithms"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/102"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/10213",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "10213",
+      "prefLabelByLang": {
+        "sv": "Formella metoder",
+        "en": "Formal Methods"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/102"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/10214",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "10214",
+      "prefLabelByLang": {
+        "sv": "Nätverks-, parallell- och distribuerad beräkning",
+        "en": "Networked, Parallel and Distributed Computing"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/102"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/10299",
@@ -281,7 +358,39 @@
         "sv": "Subatomär fysik",
         "en": "Subatomic Physics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/103"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/103"},
+      "scopeNoteByLang": {"sv": "Sammanslagning av ämnen"},
+      "historyNoteByLang": {"sv": "Acceleratorfysik och instrumentering 10306 (SSIF2011) ingår numera i Subatomär fysik 10301 (SSIF2025)."},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "fält- och partikelfysik",
+            "en": "Particle and Field Physics"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "astropartikelfysik",
+            "en": "Astroparticle Physics"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "kärnfysik",
+            "en": "Nuclear Physics"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "acceleratorfysik",
+            "en": "Accelerator Physics"
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/10302",
@@ -292,7 +401,30 @@
         "sv": "Atom- och molekylfysik och optik",
         "en": "Atom and Molecular Physics and Optics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/103"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/103"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "kemisk fysik",
+            "en": "Chemical Physics"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "kvantoptik",
+            "en": "Quantum Optics"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "",
+            "en": ""
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/10303",
@@ -314,7 +446,23 @@
         "sv": "Den kondenserade materiens fysik",
         "en": "Condensed Matter Physics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/103"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/103"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "materialfysik",
+            "en": "Material Physics"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "nanofysik",
+            "en": "Nano Physics"
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/10305",
@@ -323,20 +471,57 @@
       "code": "10305",
       "prefLabelByLang": {
         "sv": "Astronomi, astrofysik och kosmologi",
-        "en": "Astronomy, Astrophysics and Cosmology"
+        "en": "Astronomy, Astrophysics, and Cosmology"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/103"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/10306",
       "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "10306",
+      "hiddenLabel": "Acceleratorfysik och instrumentering",
+      "isReplacedBy": [
+        {"@id": "https://id.kb.se/term/ssif/10301"}
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/10603",
+      "@type": "Classification",
+      "code": "10603",
+      "hiddenLabelByLang": {"sv": "Biofysik"},
+      "isReplacedBy": [
+        {
+          "@id": "https://id.kb.se/term/ssif/10307",
+          "@annotation": {
+            "commentByLang": {"sv": "Bytt forskningsämnesgrupp"}
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/10307",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "10307",
       "prefLabelByLang": {
-        "sv": "Acceleratorfysik och instrumentering",
-        "en": "Accelerator Physics and Instrumentation"
+        "sv": "Biofysik",
+        "en": "Biophysics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/103"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/103"},
+      "scopeNoteByLang": {"sv": "Bytt forskningsämnesgrupp"},
+      "historyNoteByLang": {"sv": "Biofysik 10307 (SSIF2025) ingick tidigare i Biologi 106 (SSIF2011)."}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/10308",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "10308",
+      "prefLabelByLang": {
+        "sv": "Statistisk fysik och komplexa system",
+        "en": "Statistical physics and complex systems"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/103"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/10399",
@@ -380,7 +565,16 @@
         "sv": "Fysikalisk kemi",
         "en": "Physical Chemistry"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/104"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/104"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "yt- och kolloidkemi",
+            "en": "Surface- and Colloid Chemistry"
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/10403",
@@ -413,7 +607,16 @@
         "sv": "Organisk kemi",
         "en": "Organic Chemistry"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/104"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/104"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "läkemedelskemi (medicinsk inriktning under 30103)",
+            "en": "Medicinal Chemistry (Medical focus at 30103)"
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/10406",
@@ -435,7 +638,49 @@
         "sv": "Teoretisk kemi",
         "en": "Theoretical Chemistry"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/104"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/104"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "beräkningskemi",
+            "en": "Computational Chemistry"
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/10602",
+      "@type": "Classification",
+      "code": "10602",
+      "hiddenLabelByLang": {"sv": "Biokemi och molekylärbiologi"},
+      "isReplacedBy": [
+        {
+          "@id": "https://id.kb.se/term/ssif/10408",
+          "@annotation": {
+            "commentByLang": {"sv": "Bytt forskningsämnesgrupp, Uppdelning av ämne"}
+          }
+        },
+        {
+          "@id": "https://id.kb.se/term/ssif/10616",
+          "@annotation": {
+            "commentByLang": {"sv": "Uppdelning av ämne"}
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/10408",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "10408",
+      "prefLabelByLang": {
+        "sv": "Biokemi",
+        "en": "Biochemistry"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/104"},
+      "scopeNoteByLang": {"sv": "Bytt forskningsämnesgrupp, Uppdelning av ämne"},
+      "historyNoteByLang": {"sv": "Biokemi och molekylärbiologi 10602 (SSIF2011) har delats upp i två ämnen. Biokemi 10408 (SSIF 2025) ingår nu i Kemi 104 medan Molekylärbiologi 10616 (SSIF2025) fortsatt ingår i Biologi 106."}
     },
     {
       "@id": "https://id.kb.se/term/ssif/10499",
@@ -454,10 +699,12 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "105",
       "prefLabelByLang": {
-        "sv": "Geovetenskap och miljövetenskap",
+        "sv": "Geovetenskap och relaterad miljövetenskap",
         "en": "Earth and Related Environmental Sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/1"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/1"},
+      "hiddenLabelByLang": {"sv": "Geovetenskap och miljövetenskap"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/10501",
@@ -465,10 +712,12 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "10501",
       "prefLabelByLang": {
-        "sv": "Klimatforskning",
-        "en": "Climate Research"
+        "sv": "Klimatvetenskap",
+        "en": "Climate Science"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/105"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/105"},
+      "hiddenLabelByLang": {"sv": "Klimatforskning"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/10502",
@@ -480,8 +729,8 @@
         "en": "Environmental Sciences"
       },
       "commentByLang": {
-        "sv": "Samhällsvetenskapliga aspekter under 507",
-        "en": "social aspects to be 507"
+        "sv": "Samhällsvetenskapliga aspekter under 50909 och lantbruksvetenskapliga under 40504",
+        "en": "Social aspects at 50909 and agricultural at 40504"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/105"}
     },
@@ -492,7 +741,7 @@
       "code": "10503",
       "prefLabelByLang": {
         "sv": "Multidisciplinär geovetenskap",
-        "en": "Geosciences, Multidisciplinary"
+        "en": "Multidisciplinary Geosciences"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/105"}
     },
@@ -505,6 +754,10 @@
         "sv": "Geologi",
         "en": "Geology"
       },
+      "commentByLang": {
+        "sv": "Geoteknik och teknisk geologi under 20106",
+        "en": "Geotechnical Engineering and Engineering Geology at 20106"
+      },
       "broader": {"@id": "https://id.kb.se/term/ssif/105"}
     },
     {
@@ -515,6 +768,10 @@
       "prefLabelByLang": {
         "sv": "Geofysik",
         "en": "Geophysics"
+      },
+      "commentByLang": {
+        "sv": "Tillämningar med jordobservationsteknik under 20703",
+        "en": "Applications with Earth Observation at 20703"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/105"}
     },
@@ -546,10 +803,12 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "10508",
       "prefLabelByLang": {
-        "sv": "Meteorologi och atmosfärforskning",
+        "sv": "Meteorologi och atmosfärsvetenskap",
         "en": "Meteorology and Atmospheric Sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/105"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/105"},
+      "hiddenLabelByLang": {"sv": "Meteorologi och atmosfärforskning"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/10509",
@@ -563,15 +822,38 @@
       "broader": {"@id": "https://id.kb.se/term/ssif/105"}
     },
     {
+      "@id": "https://id.kb.se/term/ssif/10510",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "10510",
+      "prefLabelByLang": {
+        "sv": "Paleontologi och paleoekologi",
+        "en": "Palaeontology and Palaeoecology"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/105"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
       "@id": "https://id.kb.se/term/ssif/10599",
       "@type": "Classification",
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "10599",
       "prefLabelByLang": {
-        "sv": "Annan geovetenskap och miljövetenskap",
-        "en": "Other Earth and Related Environmental Sciences"
+        "sv": "Annan geovetenskap",
+        "en": "Other Earth Sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/105"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/105"},
+      "hiddenLabelByLang": {"sv": "Annan geovetenskap och miljövetenskap"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "geografisk informationsvetenskap",
+            "en": "Geographical Information Science"
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/106",
@@ -584,7 +866,7 @@
       },
       "commentByLang": {
         "sv": "Medicinska tillämpningar under 3 och lantbruksvetenskapliga under 4",
-        "en": "Medical to be 3 and Agricultural to be 4"
+        "en": "Medical aspects at 3 and agricultural at 4"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/1"}
     },
@@ -596,28 +878,6 @@
       "prefLabelByLang": {
         "sv": "Strukturbiologi",
         "en": "Structural Biology"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/106"}
-    },
-    {
-      "@id": "https://id.kb.se/term/ssif/10602",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
-      "code": "10602",
-      "prefLabelByLang": {
-        "sv": "Biokemi och molekylärbiologi",
-        "en": "Biochemistry and Molecular Biology"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/106"}
-    },
-    {
-      "@id": "https://id.kb.se/term/ssif/10603",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
-      "code": "10603",
-      "prefLabelByLang": {
-        "sv": "Biofysik",
-        "en": "Biophysics"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/106"}
     },
@@ -642,8 +902,8 @@
         "en": "Immunology"
       },
       "commentByLang": {
-        "sv": "medicinsk under 30110 och lantbruksvetenskaplig under 40302",
-        "en": "medical  to be 30110 and agricultural to be 40302"
+        "sv": "medicinska aspekter under 30110 och lantbruksvetenskapliga under 40302",
+        "en": "Medical aspects at 30110 and agricultural at 40302"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/106"}
     },
@@ -657,8 +917,8 @@
         "en": "Microbiology"
       },
       "commentByLang": {
-        "sv": "medicinsk under 30109 och lantbruksvetenskaplig under 40302",
-        "en": "medical  to be 30109 and agricultural to be 40302"
+        "sv": "medicinska aspekter under 30109 och lantbruksvetenskapliga under 40302",
+        "en": "Medical aspects at 30109 and agricultural at 40302"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/106"}
     },
@@ -690,14 +950,16 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "10609",
       "prefLabelByLang": {
-        "sv": "Genetik",
-        "en": "Genetics"
+        "sv": "Genetik och genomik",
+        "en": "Genetics and Genomics"
       },
       "commentByLang": {
-        "sv": "medicinsk under 30107 och lantbruksvetenskaplig under 40402",
-        "en": "medical to be 30107 and agricultural to be 40402"
+        "sv": "medicinska aspekter under 30107 och lantbruksvetenskapliga under 40402",
+        "en": "Medical aspects at 30107 and agricultural at 40402"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/106"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/106"},
+      "hiddenLabelByLang": {"sv": "Genetik (medicinsk under 30107 och lantbruksvetenskaplig under 40402)"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/10610",
@@ -705,14 +967,32 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "10610",
       "prefLabelByLang": {
-        "sv": "Bioinformatik och systembiologi",
-        "en": "Bioinformatics and Systems Biology"
+        "sv": "Bioinformatik och beräkningsbiologi",
+        "en": "Bioinformatics and Computational Biology"
       },
       "commentByLang": {
         "sv": "metodutveckling under 10203",
-        "en": "methods development to be 10203"
+        "en": "Methods development to be 10203"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/106"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/106"},
+      "hiddenLabelByLang": {"sv": "Bioinformatik och systembiologi (metodutveckling under 10203)"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "modellering",
+            "en": "Modelling"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "maskininlärning",
+            "en": "Machine Learning"
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/10611",
@@ -723,7 +1003,30 @@
         "sv": "Ekologi",
         "en": "Ecology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/106"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/106"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "bevarandebiologi (biodiversitet med lantbruksvetenskaplig inriktning under 40504)",
+            "en": "Biodiversity Conservation (Biodiversity within agricultural sciences at 40504)"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "",
+            "en": ""
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "",
+            "en": ""
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/10612",
@@ -770,6 +1073,19 @@
       "broader": {"@id": "https://id.kb.se/term/ssif/106"}
     },
     {
+      "@id": "https://id.kb.se/term/ssif/10616",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "10616",
+      "prefLabelByLang": {
+        "sv": "Molekylärbiologi",
+        "en": "Molecular Biology"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/106"},
+      "scopeNoteByLang": {"sv": "Uppdelning av ämne"},
+      "historyNoteByLang": {"sv": "Biokemi och molekylärbiologi 10602 (SSIF2011) har delats upp i två separata ämnen. Biokemi 10408 (SSIF 2025) ingår nu i Kemi 104 medan Molekylärbiologi 10616 (SSIF2025) fortsatt ingår i Biologi 106."}
+    },
+    {
       "@id": "https://id.kb.se/term/ssif/10699",
       "@type": "Classification",
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
@@ -797,10 +1113,12 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "10799",
       "prefLabelByLang": {
-        "sv": "Övrig annan naturvetenskap",
-        "en": "Other Natural Sciences not elsewhere specified"
+        "sv": "Annan naturvetenskap",
+        "en": "Other Natural Sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/107"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/107"},
+      "hiddenLabelByLang": {"sv": "Övrig annan naturvetenskap"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/2",
@@ -840,10 +1158,22 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "20102",
       "prefLabelByLang": {
-        "sv": "Byggproduktion",
+        "sv": "Byggprocess och förvaltning",
         "en": "Construction Management"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/201"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/201"},
+      "hiddenLabelByLang": {"sv": "Byggproduktion"},
+      "scopeNoteByLang": {"sv": "Sammanslagning av ämnen"},
+      "historyNoteByLang": {"sv": "Miljöanalys och bygginformatik 20108 (SSIF2011) och Byggproduktion 20102 (SSIF2011) har slagits samman till Byggprocess och förvaltning 20102 (SSIF2025)."},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "miljöanalys och bygginformationsteknik",
+            "en": "Environmental Analysis and Construction Information Technology"
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/20103",
@@ -884,10 +1214,12 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "20106",
       "prefLabelByLang": {
-        "sv": "Geoteknik",
-        "en": "Geotechnical Engineering"
+        "sv": "Geoteknik och teknisk geologi",
+        "en": "Geotechnical Engineering and Engineering Geology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/201"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/201"},
+      "hiddenLabelByLang": {"sv": "Geoteknik"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/20107",
@@ -903,13 +1235,35 @@
     {
       "@id": "https://id.kb.se/term/ssif/20108",
       "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "20108",
+      "hiddenLabel": "Miljöanalys och bygginformationsteknik",
+      "isReplacedBy": [
+        {"@id": "https://id.kb.se/term/ssif/20102"}
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/20109",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "20109",
       "prefLabelByLang": {
-        "sv": "Miljöanalys och bygginformationsteknik",
-        "en": "Environmental Analysis and  Construction Information Technology"
+        "sv": "Byggkonstruktion",
+        "en": "Structural Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/201"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/201"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/20110",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "20110",
+      "prefLabelByLang": {
+        "sv": "Byggnadsmaterial",
+        "en": "Building materials"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/201"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/20199",
@@ -939,10 +1293,12 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "20201",
       "prefLabelByLang": {
-        "sv": "Robotteknik och automation",
-        "en": "Robotics"
+        "sv": "Robotik och automation",
+        "en": "Robotics and automation"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/202"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/202"},
+      "hiddenLabelByLang": {"sv": "Robotteknik och automation"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/20202",
@@ -1011,6 +1367,34 @@
       "broader": {"@id": "https://id.kb.se/term/ssif/202"}
     },
     {
+      "@id": "https://id.kb.se/term/ssif/20208",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "20208",
+      "prefLabelByLang": {
+        "sv": "Datorseende och lärande system",
+        "en": "Computer Vision and learning System"
+      },
+      "commentByLang": {
+        "sv": "datavetenskapliga aspekter under 10207",
+        "en": "Computer Sciences aspects in 10207"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/202"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/20209",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "20209",
+      "prefLabelByLang": {
+        "sv": "Elkraftsystem och -komponenter",
+        "en": "Power Systems and Components"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/202"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
       "@id": "https://id.kb.se/term/ssif/20299",
       "@type": "Classification",
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
@@ -1049,21 +1433,38 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "20302",
       "prefLabelByLang": {
-        "sv": "Rymd- och flygteknik",
-        "en": "Aerospace Engineering"
+        "sv": "Farkost och rymdteknik",
+        "en": "Vehicle and Aerospace Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/203"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/203"},
+      "hiddenLabelByLang": {"sv": "Rymd- och flygteknik"},
+      "scopeNoteByLang": {"sv": "Sammanslagning av ämnen"},
+      "historyNoteByLang": {"sv": "Farkostteknik 20303 (SSIF2011) och Rymd- och flygteknik 20302 (SSIF 2011) har slagits samman till Farkost och rymdteknik 20302 (SSIF2025)."},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "flygteknik",
+            "en": ""
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "",
+            "en": ""
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/20303",
       "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "20303",
-      "prefLabelByLang": {
-        "sv": "Farkostteknik",
-        "en": "Vehicle Engineering"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/203"}
+      "hiddenLabel": "Farkostteknik",
+      "isReplacedBy": [
+        {"@id": "https://id.kb.se/term/ssif/20302"}
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/20304",
@@ -1093,10 +1494,13 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "20306",
       "prefLabelByLang": {
-        "sv": "Strömningsmekanik och akustik",
-        "en": "Fluid Mechanics and Acoustics"
+        "sv": "Strömningsmekanik",
+        "en": "Fluid Mechanics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/203"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/203"},
+      "hiddenLabelByLang": {"sv": "Strömningsmekanik och akustik"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"},
+      "historyNoteByLang": {"sv": "Akustik som tidigare var del av ämnet ingår numera i Annan maskinteknik 20399 (SSIF2025)."}
     },
     {
       "@id": "https://id.kb.se/term/ssif/20307",
@@ -1112,17 +1516,23 @@
     {
       "@id": "https://id.kb.se/term/ssif/20308",
       "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "20308",
+      "hiddenLabel": "Tribologi (ytteknik omfattande friktion, nötning och smörjning)",
+      "isReplacedBy": [
+        {"@id": "https://id.kb.se/term/ssif/20399"}
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/20309",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "20309",
       "prefLabelByLang": {
-        "sv": "Tribologi",
-        "en": "Tribology"
+        "sv": "Solid- och strukturmekanik",
+        "en": "Solid and Structural Mechanics"
       },
-      "commentByLang": {
-        "sv": "ytteknik omfattande friktion, nötning och smörjning",
-        "en": "interacting surfaces including Friction, Lubrication and Wear"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/203"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/203"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/20399",
@@ -1133,7 +1543,67 @@
         "sv": "Annan maskinteknik",
         "en": "Other Mechanical Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/203"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/203"},
+      "scopeNoteByLang": {"sv": "Annan"},
+      "historyNoteByLang": {"sv": "Tribologi 20308 (SSIF2011) och akustik som var en delmängd av 20306 (SSIF2011) ingår numera i Annan maskinteknik 20399 (SSIF2025). Industriell ekonomi 20310 (SSIF2025) ingick tidigare i Annan maskinteknik 20399 (SSIF2011)."},
+      "related": [
+        {
+          "@id": "https://id.kb.se/term/ssif/20310",
+          "@annotation": {
+            "commentByLang": {"sv": "Uppdelning av ämne"}
+          }
+        }
+      ],
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "logistik",
+            "en": "Logistics"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "förbränningsteknik",
+            "en": "Combustion Technology"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "återvinningsteknik",
+            "en": "Recycling Technology"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "tribologi",
+            "en": "Tribology"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "akustik",
+            "en": "Acoustics"
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/20310",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "20310",
+      "prefLabelByLang": {
+        "sv": "Industriell ekonomi",
+        "en": "Industrial engineering and management"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/203"},
+      "scopeNoteByLang": {"sv": "Uppdelning av ämne"},
+      "historyNoteByLang": {"sv": "Industriell ekonomi 20310 (SSIF2025) ingick tidigare i Annan maskinteknik 20399 (SSIF2011)."}
     },
     {
       "@id": "https://id.kb.se/term/ssif/204",
@@ -1147,26 +1617,26 @@
       "broader": {"@id": "https://id.kb.se/term/ssif/2"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20401",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
-      "code": "20401",
-      "prefLabelByLang": {
-        "sv": "Kemiska processer",
-        "en": "Chemical Process Engineering"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/204"}
-    },
-    {
       "@id": "https://id.kb.se/term/ssif/20402",
       "@type": "Classification",
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "20402",
       "prefLabelByLang": {
-        "sv": "Korrosionsteknik",
-        "en": "Corrosion Engineering"
+        "sv": "Yt- och korrosionsteknik",
+        "en": "Surface- and Corrosion Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/204"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/204"},
+      "hiddenLabelByLang": {"sv": "Korrosionsteknik"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "kemisk tribologi",
+            "en": "Chemical tribology"
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/20403",
@@ -1182,13 +1652,90 @@
     {
       "@id": "https://id.kb.se/term/ssif/20404",
       "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "20404",
+      "hiddenLabel": "Farmaceutisk synteskemi",
+      "isReplacedBy": [
+        {"@id": "https://id.kb.se/term/ssif/20499"}
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/20401",
+      "@type": "Classification",
+      "code": "20401",
+      "hiddenLabelByLang": {"sv": "Kemiska processer"},
+      "isReplacedBy": [
+        {
+          "@id": "https://id.kb.se/term/ssif/20405",
+          "@annotation": {
+            "commentByLang": {"sv": "Uppdelning av ämne"}
+          }
+        },
+        {
+          "@id": "https://id.kb.se/term/ssif/20406",
+          "@annotation": {
+            "commentByLang": {"sv": "Uppdelning av ämne"}
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/20405",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "20405",
       "prefLabelByLang": {
-        "sv": "Farmaceutisk synteskemi",
-        "en": "Pharmaceutical Chemistry"
+        "sv": "Katalytiska processer",
+        "en": "Catalytic Processes"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/204"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/204"},
+      "scopeNoteByLang": {"sv": "Uppdelning av ämne"},
+      "historyNoteByLang": {"sv": "Kemiska processer 20401 (SSIF2011) har delats upp i Katalytiska processer 20405 (SSIF2025) och Separationsprocesser 20406 (SSIF2025)."}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/20406",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "20406",
+      "prefLabelByLang": {
+        "sv": "Separationsprocesser",
+        "en": "Separation Processes"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/204"},
+      "scopeNoteByLang": {"sv": "Uppdelning av ämne"},
+      "historyNoteByLang": {"sv": "Kemiska processer 20401 (SSIF2011) har delats upp i Katalytiska processer 20405 (SSIF2025) och Separationsprocesser 20406 (SSIF2025)."}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/21101",
+      "@type": "Classification",
+      "code": "21101",
+      "hiddenLabelByLang": {"sv": "Livsmedelsteknik"},
+      "isReplacedBy": [
+        {
+          "@id": "https://id.kb.se/term/ssif/20407",
+          "@annotation": {
+            "commentByLang": {"sv": "Bytt forskningsämnesgrupp, Uppdelning av ämne"}
+          }
+        },
+        {
+          "@id": "https://id.kb.se/term/ssif/20909",
+          "@annotation": {
+            "commentByLang": {"sv": "Bytt forskningsämnesgrupp, Uppdelning av ämne"}
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/20407",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "20407",
+      "prefLabelByLang": {
+        "sv": "Livsmedelsprocessteknik",
+        "en": "Circular Food Process Technologies"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/204"},
+      "scopeNoteByLang": {"sv": "Bytt forskningsämnesgrupp, Uppdelning av ämne"},
+      "historyNoteByLang": {"sv": "Livsmedelsteknik 21101 (SSIF2011) har nu delats upp i Livsmedelsbioteknik 20909 (SSIF2025) och Livsmedelsprocessteknik 20407 (SSIF2025)"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/20499",
@@ -1218,10 +1765,12 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "20501",
       "prefLabelByLang": {
-        "sv": "Keramteknik",
-        "en": "Ceramics"
+        "sv": "Keramiska och pulvermetallurgiska material",
+        "en": "Ceramics and Powder Metallurgical Materials"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/205"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/205"},
+      "hiddenLabelByLang": {"sv": "Keramteknik"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/20502",
@@ -1229,7 +1778,7 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "20502",
       "prefLabelByLang": {
-        "sv": "Kompositmaterial och -teknik",
+        "sv": "Kompositmaterial och kompositteknik",
         "en": "Composite Science and Engineering"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/205"}
@@ -1306,10 +1855,13 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "20601",
       "prefLabelByLang": {
-        "sv": "Medicinsk laboratorie- och mätteknik",
-        "en": "Medical Laboratory and Measurements Technologies"
+        "sv": "Medicinsk laboratorieteknik",
+        "en": "Medical Laboratory Technologies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/206"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/206"},
+      "hiddenLabelByLang": {"sv": "Medicinsk laboratorie- och mätteknik"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"},
+      "historyNoteByLang": {"sv": "Mätteknik som tidigare var del av ämnet ingår numera i Medicinsk instrumentering 20604 (SSIF2025)"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/20602",
@@ -1317,10 +1869,21 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "20602",
       "prefLabelByLang": {
-        "sv": "Medicinsk material- och protesteknik",
+        "sv": "Medicinsk materialteknik",
         "en": "Medical Materials"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/206"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/206"},
+      "hiddenLabelByLang": {"sv": "Medicinsk material- och protesteknik"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "protesteknik",
+            "en": "Prosthesis technologies"
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/20603",
@@ -1328,10 +1891,12 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "20603",
       "prefLabelByLang": {
-        "sv": "Medicinsk bildbehandling",
-        "en": "Medical Image Processing"
+        "sv": "Medicinsk bildvetenskap",
+        "en": "Medical Imaging"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/206"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/206"},
+      "hiddenLabelByLang": {"sv": "Medicinsk bildbehandling"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/20604",
@@ -1339,10 +1904,22 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "20604",
       "prefLabelByLang": {
-        "sv": "Medicinsk apparatteknik",
-        "en": "Medical Equipment Engineering"
+        "sv": "Medicinsk instrumentering",
+        "en": "Medical Instrumentation"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/206"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/206"},
+      "hiddenLabelByLang": {"sv": "Medicinsk apparatteknik"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"},
+      "historyNoteByLang": {"sv": "Mätteknik som tidigare var del av 20601 (SSIF2011) ingår numera i Medicinsk instrumentering 20604 (SSIF2025)"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "mätteknik",
+            "en": "Measurement Technologies"
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/20605",
@@ -1350,10 +1927,28 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "20605",
       "prefLabelByLang": {
-        "sv": "Medicinsk ergonomi",
-        "en": "Medical Ergonomics"
+        "sv": "Medicinsk modellering och simulering",
+        "en": "Medical Modelling and Simulation"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/206"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/206"},
+      "hiddenLabelByLang": {"sv": "Medicinsk ergonomi"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/20606",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "20606",
+      "prefLabelByLang": {
+        "sv": "Medicinteknisk informatik",
+        "en": "Medical Informatics Engineering"
+      },
+      "commentByLang": {
+        "sv": "medicinska aspekter under 30117",
+        "en": "Medical aspects at 30117"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/206"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/20699",
@@ -1380,13 +1975,11 @@
     {
       "@id": "https://id.kb.se/term/ssif/20701",
       "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "20701",
-      "prefLabelByLang": {
-        "sv": "Geofysisk teknik",
-        "en": "Geophysical Engineering"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/207"}
+      "hiddenLabel": "Geofysisk teknik",
+      "isReplacedBy": [
+        {"@id": "https://id.kb.se/term/ssif/20703"}
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/20702",
@@ -1405,10 +1998,43 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "20703",
       "prefLabelByLang": {
-        "sv": "Fjärranalysteknik",
-        "en": "Remote Sensing"
+        "sv": "Jordobservationsteknik",
+        "en": "Earth Observation"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/207"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/207"},
+      "hiddenLabelByLang": {"sv": "Fjärranalysteknik"},
+      "scopeNoteByLang": {"sv": "Sammanslagning av ämnen"},
+      "historyNoteByLang": {"sv": "Geofysisk teknik 20701 (SSIF2011) och Fjärranalysteknik 20703 (SSIF2011) har slagits samman till Jordobservationsteknik 20703 (SSIF2025)."},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "teknik för fjärranalys",
+            "en": "Remote Sensing"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "geodesi",
+            "en": "Geodesy"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "geofysisk teknik",
+            "en": "Geophysical Engineering"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "geografisk informationsteknik",
+            "en": "Geographical information technology"
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/20704",
@@ -1427,21 +2053,38 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "20705",
       "prefLabelByLang": {
-        "sv": "Marin teknik",
+        "sv": "Marinteknik",
         "en": "Marine Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/207"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/207"},
+      "hiddenLabelByLang": {"sv": "Marin teknik"},
+      "scopeNoteByLang": {"sv": "Sammanslagning av ämnen"},
+      "historyNoteByLang": {"sv": "Havs- och vattendragsteknik 20706 (SSIF2011) ingår numera i Marinteknik 20705 (SSIF2025)."},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "havs- och vattendragsteknik",
+            "en": "Ocean and River Engineering"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "",
+            "en": ""
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/20706",
       "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "20706",
-      "prefLabelByLang": {
-        "sv": "Havs- och vattendragsteknik",
-        "en": "Ocean and River Engineering"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/207"}
+      "hiddenLabel": "Havs- och vattendragsteknik",
+      "isReplacedBy": [
+        {"@id": "https://id.kb.se/term/ssif/20705"}
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/20707",
@@ -1449,10 +2092,12 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "20707",
       "prefLabelByLang": {
-        "sv": "Miljöledning",
+        "sv": "Miljöteknik och miljöledning",
         "en": "Environmental Management"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/207"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/207"},
+      "hiddenLabelByLang": {"sv": "Miljöledning"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/20799",
@@ -1504,21 +2149,21 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "20803",
       "prefLabelByLang": {
-        "sv": "Vattenbehandling",
+        "sv": "Vattenbehandlingsbioteknik",
         "en": "Water Treatment"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/208"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/208"},
+      "hiddenLabelByLang": {"sv": "Vattenbehandling"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/20804",
       "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "20804",
-      "prefLabelByLang": {
-        "sv": "Bioteknisk etik",
-        "en": "Bioethics"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/208"}
+      "hiddenLabel": "Bioteknisk etik",
+      "isReplacedBy": [
+        {"@id": "https://id.kb.se/term/ssif/20899"}
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/20899",
@@ -1551,7 +2196,18 @@
         "sv": "Bioprocessteknik",
         "en": "Bioprocess Technology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/209"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/209"},
+      "scopeNoteByLang": {"sv": "Sammanslagning av ämnen"},
+      "historyNoteByLang": {"sv": "Bioteknisk apparatteknik 20907 (SSIF2011) ingår numera i Bioprocessteknik 20901 (SSIF2025)."},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "bioteknisk apparatteknik",
+            "en": "Bioengineering Equipment"
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/20902",
@@ -1584,7 +2240,9 @@
         "sv": "Bioenergi",
         "en": "Bioenergy"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/209"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/209"},
+      "scopeNoteByLang": {"sv": "Annan"},
+      "historyNoteByLang": {"sv": "Förnyelsebar bioenergi 40501 (SSIF2011) ingår nu i 20904 (SSIF2025)."}
     },
     {
       "@id": "https://id.kb.se/term/ssif/20905",
@@ -1592,10 +2250,13 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "20905",
       "prefLabelByLang": {
-        "sv": "Läkemedelsbioteknik",
-        "en": "Pharmaceutical Biotechnology"
+        "sv": "Läkemedel- och medicinsk processbioteknik",
+        "en": "Pharmaceutical and Medical Biotechnology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/209"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/209"},
+      "hiddenLabelByLang": {"sv": "Läkemedelsbioteknik"},
+      "scopeNoteByLang": {"sv": "Sammanslagning av ämnen"},
+      "historyNoteByLang": {"sv": "Läkemedelsbioteknik 20905 (SSIF2011) och Medicinsk bioteknik 20908 (SSIF2011) har slagits samman till Läkemedel- och medicinsk processbioteknik 20905 (SSIF2025)."}
     },
     {
       "@id": "https://id.kb.se/term/ssif/20906",
@@ -1611,24 +2272,33 @@
     {
       "@id": "https://id.kb.se/term/ssif/20907",
       "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "20907",
-      "prefLabelByLang": {
-        "sv": "Bioteknisk apparatteknik",
-        "en": "Bioengineering Equipment"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/209"}
+      "hiddenLabel": "Bioteknisk apparatteknik",
+      "isReplacedBy": [
+        {"@id": "https://id.kb.se/term/ssif/20901"}
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/20908",
       "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "20908",
+      "hiddenLabel": "Medicinsk bioteknik",
+      "isReplacedBy": [
+        {"@id": "https://id.kb.se/term/ssif/20905"}
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/20909",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "20909",
       "prefLabelByLang": {
-        "sv": "Medicinsk bioteknik",
-        "en": "Medical Biotechnology"
+        "sv": "Livsmedelsbioteknik",
+        "en": "Food Biotechnology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/209"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/209"},
+      "scopeNoteByLang": {"sv": "Bytt forskningsämnesgrupp, Uppdelning av ämne"},
+      "historyNoteByLang": {"sv": "Livsmedelsteknik 21101 (SSIF2011) har nu delats upp i Livsmedelsbioteknik 20909 (SSIF2025) och Livsmedelsprocessteknik 20407 (SSIF2025)."}
     },
     {
       "@id": "https://id.kb.se/term/ssif/20999",
@@ -1655,13 +2325,74 @@
     {
       "@id": "https://id.kb.se/term/ssif/21001",
       "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "21001",
+      "hiddenLabel": "Nanoteknik",
+      "isReplacedBy": [
+        {"@id": "https://id.kb.se/term/ssif/21002"},
+        {"@id": "https://id.kb.se/term/ssif/21003"},
+        {"@id": "https://id.kb.se/term/ssif/21004"},
+        {"@id": "https://id.kb.se/term/ssif/21005"}
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/21002",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "21002",
       "prefLabelByLang": {
-        "sv": "Nanoteknik",
-        "en": "Nano-technology"
+        "sv": "Nanoteknisk elektronik",
+        "en": "Nanotechnology for Electronic Applications"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/210"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/210"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/21003",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "21003",
+      "prefLabelByLang": {
+        "sv": "Nanoteknisk materialvetenskap",
+        "en": "Nanotechnology for Material Science"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/210"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/21004",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "21004",
+      "prefLabelByLang": {
+        "sv": "Nanotekniska energitillämpningar",
+        "en": "Nanotechnology for Energy Applications"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/210"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/21005",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "21005",
+      "prefLabelByLang": {
+        "sv": "Nanotekniska livsvetenskaper och medicin",
+        "en": "Nanotechnology for/in Life Science and Medicine"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/210"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/21099",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "21099",
+      "prefLabelByLang": {
+        "sv": "Annan nanoteknik",
+        "en": "Other Nanotechnology"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/210"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/211",
@@ -1675,37 +2406,22 @@
       "broader": {"@id": "https://id.kb.se/term/ssif/2"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/21101",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
-      "code": "21101",
-      "prefLabelByLang": {
-        "sv": "Livsmedelsteknik",
-        "en": "Food Engineering"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/211"}
-    },
-    {
       "@id": "https://id.kb.se/term/ssif/21102",
       "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "21102",
-      "prefLabelByLang": {
-        "sv": "Mediateknik",
-        "en": "Media Engineering"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/211"}
+      "hiddenLabel": "Mediateknik",
+      "isReplacedBy": [
+        {"@id": "https://id.kb.se/term/ssif/21199"}
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/21103",
       "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "21103",
-      "prefLabelByLang": {
-        "sv": "Interaktionsteknik",
-        "en": "Interaction Technologies"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/211"}
+      "hiddenLabel": "Interaktionsteknik",
+      "isReplacedBy": [
+        {"@id": "https://id.kb.se/term/ssif/21199"}
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/21199",
@@ -1713,10 +2429,12 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "21199",
       "prefLabelByLang": {
-        "sv": "Övrig annan teknik",
-        "en": "Other Engineering and Technologies not elsewhere specified"
+        "sv": "Annan teknik",
+        "en": "Other Engineering and Technologies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/211"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/211"},
+      "hiddenLabelByLang": {"sv": "Övrig annan teknik"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/3",
@@ -1770,6 +2488,10 @@
         "sv": "Läkemedelskemi",
         "en": "Medicinal Chemistry"
       },
+      "commentByLang": {
+        "sv": "naturvetenskaplig inriktning under 10405",
+        "en": "Natural Sciences at 10405"
+      },
       "broader": {"@id": "https://id.kb.se/term/ssif/301"}
     },
     {
@@ -1800,10 +2522,12 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "30106",
       "prefLabelByLang": {
-        "sv": "Fysiologi",
-        "en": "Physiology"
+        "sv": "Fysiologi och anatomi",
+        "en": "Physiology and Anatomy"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/301"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/301"},
+      "hiddenLabelByLang": {"sv": "Fysiologi"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/30107",
@@ -1811,10 +2535,21 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "30107",
       "prefLabelByLang": {
-        "sv": "Medicinsk genetik",
-        "en": "Medical Genetics"
+        "sv": "Medicinsk genetik och genomik",
+        "en": "Medical Genetics and Genomics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/301"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/301"},
+      "hiddenLabelByLang": {"sv": "Medicinsk genetik"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "genterapi",
+            "en": "Gene Therapy"
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/30108",
@@ -1834,7 +2569,7 @@
       "code": "30109",
       "prefLabelByLang": {
         "sv": "Mikrobiologi inom det medicinska området",
-        "en": "Microbiology in the medical area"
+        "en": "Microbiology in the Medical Area"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/301"}
     },
@@ -1845,9 +2580,148 @@
       "code": "30110",
       "prefLabelByLang": {
         "sv": "Immunologi inom det medicinska området",
-        "en": "Immunology in the medical area"
+        "en": "Immunology in the Medical Area"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/301"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/301"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "cell- och immunterapi",
+            "en": "Cell and Immunotherapy"
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/30111",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "30111",
+      "prefLabelByLang": {
+        "sv": "Medicinska biovetenskaper",
+        "en": "Medical Life Sciences"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/301"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "patologi och biokemi",
+            "en": "Pathology and Biochemistry"
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/30112",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "30112",
+      "prefLabelByLang": {
+        "sv": "Basal cancerforskning",
+        "en": "Basic Cancer Research"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/301"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/30113",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "30113",
+      "prefLabelByLang": {
+        "sv": "Medicinsk bioinformatik och systembiologi",
+        "en": "Medical Bioinformatics and Systems Biology"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/301"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/30114",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "30114",
+      "prefLabelByLang": {
+        "sv": "Evolution och utvecklingsgenetik",
+        "en": "Evolution and Developmental Genetics"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/301"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/30115",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "30115",
+      "prefLabelByLang": {
+        "sv": "Medicinsk epigenetik och epigenomik",
+        "en": "Medical Epigenetics and Epigenomics"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/301"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/30302",
+      "@type": "Classification",
+      "code": "30302",
+      "hiddenLabelByLang": {"sv": "Folkhälsovetenskap, global hälsa, socialmedicin och epidemiologi"},
+      "isReplacedBy": [
+        {
+          "@id": "https://id.kb.se/term/ssif/30116",
+          "@annotation": {
+            "commentByLang": {"sv": "Bytt forskningsämnesgrupp, Uppdelning av ämne"}
+          }
+        },
+        {
+          "@id": "https://id.kb.se/term/ssif/30311",
+          "@annotation": {
+            "commentByLang": {"sv": "Uppdelning av ämne"}
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/30116",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "30116",
+      "prefLabelByLang": {
+        "sv": "Epidemiologi",
+        "en": "Epidemiology"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/301"},
+      "scopeNoteByLang": {"sv": "Bytt forskningsämnesgrupp, Uppdelning av ämne"},
+      "historyNoteByLang": {"sv": "Epidemiologi 30116 (SSIF2025) var tidigare en del av Folkhälsovetenskap, global hälsa, socialmedicin och epidemiologi 30302 (SSIF2011) men utgör numera ett eget ämne."}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/30117",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "30117",
+      "prefLabelByLang": {
+        "sv": "Medicinsk informatik",
+        "en": "Medical Informatics"
+      },
+      "commentByLang": {
+        "sv": "tekniska aspekter under 20606",
+        "en": "Technical aspects at 20606"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/301"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/30118",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "30118",
+      "prefLabelByLang": {
+        "sv": "Medicinsk biostatistik",
+        "en": "Medical Biostatistics"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/301"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/30199",
@@ -1902,7 +2776,16 @@
         "sv": "Cancer och onkologi",
         "en": "Cancer and Oncology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/302"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "precisionsmedicin",
+            "en": "Precision Medicine"
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/30204",
@@ -1932,10 +2815,12 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "30206",
       "prefLabelByLang": {
-        "sv": "Kardiologi",
-        "en": "Cardiac and Cardiovascular Systems"
+        "sv": "Kardiologi och kardiovaskulära sjukdomar",
+        "en": "Cardiology and Cardiovascular Disease"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/302"},
+      "hiddenLabelByLang": {"sv": "Kardiologi"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/30207",
@@ -1955,7 +2840,7 @@
       "code": "30208",
       "prefLabelByLang": {
         "sv": "Radiologi och bildbehandling",
-        "en": "Radiology, Nuclear Medicine and Medical Imaging"
+        "en": "Radiology and Medical Imaging"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/302"}
     },
@@ -1967,17 +2852,6 @@
       "prefLabelByLang": {
         "sv": "Infektionsmedicin",
         "en": "Infectious Medicine"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"}
-    },
-    {
-      "@id": "https://id.kb.se/term/ssif/30210",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
-      "code": "30210",
-      "prefLabelByLang": {
-        "sv": "Reumatologi och inflammation",
-        "en": "Rheumatology and Autoimmunity"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/302"}
     },
@@ -2001,7 +2875,16 @@
         "sv": "Kirurgi",
         "en": "Surgery"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/302"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "kirurgiska subspecialiteter",
+            "en": "Surgical Subspecialties"
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/30213",
@@ -2009,21 +2892,12 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "30213",
       "prefLabelByLang": {
-        "sv": "Gastroenterologi",
+        "sv": "Gastroenterologi och hepatologi",
         "en": "Gastroenterology and Hepatology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"}
-    },
-    {
-      "@id": "https://id.kb.se/term/ssif/30214",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
-      "code": "30214",
-      "prefLabelByLang": {
-        "sv": "Urologi och njurmedicin",
-        "en": "Urology and Nephrology"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/302"},
+      "hiddenLabelByLang": {"sv": "Gastroenterologi"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/30215",
@@ -2043,7 +2917,7 @@
       "code": "30216",
       "prefLabelByLang": {
         "sv": "Odontologi",
-        "en": "Dentistry"
+        "en": "Odontology"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/302"}
     },
@@ -2065,7 +2939,7 @@
       "code": "30218",
       "prefLabelByLang": {
         "sv": "Oto-rhino-laryngologi",
-        "en": "Otorhinolaryngology"
+        "en": "Oto-rhino-laryngology"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/302"}
     },
@@ -2086,10 +2960,12 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "30220",
       "prefLabelByLang": {
-        "sv": "Reproduktionsmedicin och gynekologi",
-        "en": "Obstetrics, Gynaecology and Reproductive Medicine"
+        "sv": "Gynekologi, obstetrik och reproduktionsmedicin",
+        "en": "Gynaecology, Obstetrics and Reproductive Medicine"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/302"},
+      "hiddenLabelByLang": {"sv": "Reproduktionsmedicin och gynekologi"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/30221",
@@ -2131,9 +3007,125 @@
       "code": "30224",
       "prefLabelByLang": {
         "sv": "Allmänmedicin",
-        "en": "General Practice"
+        "en": "General Medicine"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/302"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/30210",
+      "@type": "Classification",
+      "code": "30210",
+      "hiddenLabelByLang": {"sv": "Reumatologi och inflammation"},
+      "isReplacedBy": [
+        {
+          "@id": "https://id.kb.se/term/ssif/30225",
+          "@annotation": {
+            "commentByLang": {"sv": "Uppdelning av ämne"}
+          }
+        },
+        {
+          "@id": "https://id.kb.se/term/ssif/30226",
+          "@annotation": {
+            "commentByLang": {"sv": "Uppdelning av ämne"}
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/30225",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "30225",
+      "prefLabelByLang": {
+        "sv": "Reumatologi",
+        "en": "Rheumatology"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/302"},
+      "scopeNoteByLang": {"sv": "Uppdelning av ämne"},
+      "historyNoteByLang": {"sv": "Reumatologi 30225 (SSIF2025) var tidigare en del av Reumatologi och inflamation 30210 (SSIF2011) men utgör numera ett eget ämne."}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/30226",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "30226",
+      "prefLabelByLang": {
+        "sv": "Autoimmunitet och inflammation",
+        "en": "Autoimmunity and Inflammation"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/302"},
+      "scopeNoteByLang": {"sv": "Uppdelning av ämne"},
+      "historyNoteByLang": {"sv": "Autoimmunitet och inflamation 30226 (SSIF2025) var tidigare en del av Reumatologi och inflamation 30210 (SSIF2011) men utgör numera ett eget ämne."}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/30227",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "30227",
+      "prefLabelByLang": {
+        "sv": "Internmedicin",
+        "en": "Internal Medicine"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/302"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/30214",
+      "@type": "Classification",
+      "code": "30214",
+      "hiddenLabelByLang": {"sv": "Urologi och njurmedicin"},
+      "isReplacedBy": [
+        {
+          "@id": "https://id.kb.se/term/ssif/30228",
+          "@annotation": {
+            "commentByLang": {"sv": "Uppdelning av ämne"}
+          }
+        },
+        {
+          "@id": "https://id.kb.se/term/ssif/30229",
+          "@annotation": {
+            "commentByLang": {"sv": "Uppdelning av ämne"}
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/30228",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "30228",
+      "prefLabelByLang": {
+        "sv": "Urologi",
+        "en": "Urology"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/302"},
+      "scopeNoteByLang": {"sv": "Uppdelning av ämne"},
+      "historyNoteByLang": {"sv": "Urologi 30228 (SSIF2025) var tidigare en del av Urologi och njurmedicin 30214 (SSIF2011) men utgör numera ett eget ämne."}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/30229",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "30229",
+      "prefLabelByLang": {
+        "sv": "Njurmedicin",
+        "en": "Nephrology"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/302"},
+      "scopeNoteByLang": {"sv": "Uppdelning av ämne"},
+      "historyNoteByLang": {"sv": "Njurmedicin 30229 (SSIF2025) var tidigare en del av Urologi och njurmedicin 30214 (SSIF2011) men utgör numera ett eget ämne."}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/30230",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "30230",
+      "prefLabelByLang": {
+        "sv": "Förlossnings- och mödravård",
+        "en": "Childbirth and Maternity care"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/302"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/30299",
@@ -2169,17 +3161,6 @@
       "broader": {"@id": "https://id.kb.se/term/ssif/303"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30302",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
-      "code": "30302",
-      "prefLabelByLang": {
-        "sv": "Folkhälsovetenskap, global hälsa, socialmedicin och epidemiologi",
-        "en": "Public Health, Global Health, Social Medicine and Epidemiology"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/303"}
-    },
-    {
       "@id": "https://id.kb.se/term/ssif/30303",
       "@type": "Classification",
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
@@ -2196,10 +3177,12 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "30304",
       "prefLabelByLang": {
-        "sv": "Näringslära",
+        "sv": "Näringslära och dietkunskap",
         "en": "Nutrition and Dietetics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/303"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/303"},
+      "hiddenLabelByLang": {"sv": "Näringslära"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/30305",
@@ -2229,10 +3212,12 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "30307",
       "prefLabelByLang": {
-        "sv": "Sjukgymnastik",
+        "sv": "Fysioterapi",
         "en": "Physiotherapy"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/303"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/303"},
+      "hiddenLabelByLang": {"sv": "Sjukgymnastik"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/30308",
@@ -2240,10 +3225,12 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "30308",
       "prefLabelByLang": {
-        "sv": "Idrottsvetenskap",
+        "sv": "Idrottsvetenskap och fitness",
         "en": "Sport and Fitness Sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/303"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/303"},
+      "hiddenLabelByLang": {"sv": "Idrottsvetenskap"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/30309",
@@ -2251,10 +3238,12 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "30309",
       "prefLabelByLang": {
-        "sv": "Beroendelära",
-        "en": "Substance Abuse"
+        "sv": "Beroendelära och missbruk",
+        "en": "Drug Abuse and Addiction"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/303"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/303"},
+      "hiddenLabelByLang": {"sv": "Beroendelära"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/30310",
@@ -2266,6 +3255,55 @@
         "en": "Medical Ethics"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/303"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/30311",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "30311",
+      "prefLabelByLang": {
+        "sv": "Folkhälsovetenskap, global hälsa och socialmedicin",
+        "en": "Public Health, Global Health and Social Medicine"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/303"},
+      "scopeNoteByLang": {"sv": "Uppdelning av ämne"},
+      "historyNoteByLang": {"sv": "Epidemiologi 30116 (SSIF2025) var tidigare en del av Folkhälsovetenskap, global hälsa, socialmedicin och epidemiologi 30302 (SSIF2011) men utgör numera ett eget ämne."}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/30312",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "30312",
+      "prefLabelByLang": {
+        "sv": "Palliativ medicin och palliativ vård",
+        "en": "Palliative Medicine and Palliative Care"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/303"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/30313",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "30313",
+      "prefLabelByLang": {
+        "sv": "Oral hälsa",
+        "en": "Oral Health"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/303"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/30314",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "30314",
+      "prefLabelByLang": {
+        "sv": "Rehabiliteringsmedicin",
+        "en": "Rehabilitation Medicine"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/303"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/30399",
@@ -2300,7 +3338,7 @@
       },
       "commentByLang": {
         "sv": "inriktn. mot cellbiologi (inkl. stamcellsbiologi), molekylärbiologi, mikrobiologi, biokemi eller biofarmaci",
-        "en": "focus on Cell Biology (incl. Stem Cell Biology), Molecular Biology, Microbiology, Biochemistry or Biopharmacy"
+        "en": "Focus on Cell Biology (incl. Stem Cell Biology), Molecular Biology, Microbiology, Biochemistry or Biopharmacy"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/304"}
     },
@@ -2369,8 +3407,8 @@
         "en": "Gerontology, specialising in Medical and Health Sciences"
       },
       "commentByLang": {
-        "sv": "Samhällsvetenskaplig inriktn.under 50999",
-        "en": "specialising in Social Sciences to be 50999"
+        "sv": "Samhällsvetenskaplig inriktn.under 50908",
+        "en": "Specialising in Social Sciences at 50908"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/305"}
     },
@@ -2401,10 +3439,12 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "401",
       "prefLabelByLang": {
-        "sv": "Lantbruksvetenskap, skogsbruk och fiske",
+        "sv": "Jordbruk, skogsbruk och fiske",
         "en": "Agriculture, Forestry and Fisheries"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/4"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/4"},
+      "hiddenLabelByLang": {"sv": "Lantbruksvetenskap, skogsbruk och fiske"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/40101",
@@ -2415,7 +3455,65 @@
         "sv": "Jordbruksvetenskap",
         "en": "Agricultural Science"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/401"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/401"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "växtgenetik",
+            "en": "Plant Genetics"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "jordbruksekologi",
+            "en": "Agricultural Ecology"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "agroteknologi",
+            "en": "Agricultural Technology"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "agrarhistoria",
+            "en": "Agricultural History"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "",
+            "en": ""
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "",
+            "en": ""
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "",
+            "en": ""
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "",
+            "en": ""
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/40102",
@@ -2437,7 +3535,44 @@
         "sv": "Livsmedelsvetenskap",
         "en": "Food Science"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/401"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/401"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "produktkvalitet",
+            "en": "Product Quality"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "",
+            "en": ""
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "",
+            "en": ""
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "",
+            "en": ""
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "",
+            "en": ""
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/40104",
@@ -2448,7 +3583,86 @@
         "sv": "Skogsvetenskap",
         "en": "Forest Science"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/401"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/401"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "skogsskötsel",
+            "en": "Silviculture"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "skogsgenetik",
+            "en": "Forest Genetics"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "skogsmykologi",
+            "en": "Forest Mycology"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "skogspatologi",
+            "en": "Forest Pathology"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "skogsteknologi",
+            "en": "Forest Technology"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "skogshistoria",
+            "en": "Forest History"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "skogsekologi",
+            "en": "Forest Ecology"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "skogsekonomi",
+            "en": "Forest Economics"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "",
+            "en": ""
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "",
+            "en": ""
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "",
+            "en": ""
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/40105",
@@ -2459,7 +3673,16 @@
         "sv": "Trävetenskap",
         "en": "Wood Science"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/401"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/401"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "träteknologi",
+            "en": "Wood Technology"
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/40106",
@@ -2470,7 +3693,37 @@
         "sv": "Markvetenskap",
         "en": "Soil Science"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/401"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/401"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "biogeofysik",
+            "en": "Biogeophysics"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "biogeokemi",
+            "en": "Biogeochemistry"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "markmikrobiologi",
+            "en": "Soil Microbiology"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "växt-mark interaktioner",
+            "en": "Plant-Soil Interactions"
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/40107",
@@ -2481,18 +3734,46 @@
         "sv": "Fisk- och akvakulturforskning",
         "en": "Fish and Aquacultural Science"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/401"}
-    },
-    {
-      "@id": "https://id.kb.se/term/ssif/40108",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
-      "code": "40108",
-      "prefLabelByLang": {
-        "sv": "Landskapsarkitektur",
-        "en": "Landscape Architecture"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/401"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/401"},
+      "scopeNoteByLang": {"sv": "Annan"},
+      "historyNoteByLang": {"sv": "Fiskpopulationsekologi ingick tidigare i Fisk- och akvakulturforskning 40107 (SSIF2011) men ingår nu i Vilt och fiskeförvaltning 40502 (SSIF2025)."},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "fiskodling",
+            "en": "Fish farming"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "fiskgenetik",
+            "en": "Fish Genetics"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "fisketologi",
+            "en": "Fish Ethology"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "",
+            "en": ""
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "",
+            "en": ""
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/402",
@@ -2501,7 +3782,7 @@
       "code": "402",
       "prefLabelByLang": {
         "sv": "Husdjursvetenskap",
-        "en": "Animal and Dairy Sience"
+        "en": "Animal and Dairy Science"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/4"}
     },
@@ -2512,9 +3793,53 @@
       "code": "40201",
       "prefLabelByLang": {
         "sv": "Husdjursvetenskap",
-        "en": "Animal and Dairy Science."
+        "en": "Animal and Dairy Science"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/402"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/402"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "djuretik",
+            "en": "Animal Ethics"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "renskötsel",
+            "en": "Reindeer Husbandry"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "",
+            "en": ""
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "",
+            "en": ""
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "",
+            "en": ""
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "",
+            "en": ""
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/403",
@@ -2536,7 +3861,30 @@
         "sv": "Medicinsk biovetenskap",
         "en": "Medical Bioscience"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/403"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/403"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "anatomi",
+            "en": "Anatomy"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "fysiologi",
+            "en": "Physiology"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "biokemi",
+            "en": "Biochemistry"
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/40302",
@@ -2547,7 +3895,51 @@
         "sv": "Patobiologi",
         "en": "Pathobiology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/403"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/403"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "immunologi",
+            "en": "Immunology"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "mikrobiologi",
+            "en": "Microbiology"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "patologi",
+            "en": "Pathology"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "toxikologi",
+            "en": "Toxicology"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "farmakologi",
+            "en": "Pharmacology"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "livsmedelssäkerhet",
+            "en": "Food Safety"
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/40303",
@@ -2558,18 +3950,91 @@
         "sv": "Klinisk vetenskap",
         "en": "Clinical Science"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/403"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/403"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "anestesiologi",
+            "en": "Anaesthesiology"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "komparativ medicin",
+            "en": "Comparative Medicine"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "diagnostik",
+            "en": "Diagnostics"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "djuromvårdnad",
+            "en": "Veterinary Nursing"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "epidemiologi",
+            "en": "Epidemiology"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "kirurgi",
+            "en": "Surgery"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "medicin",
+            "en": "Medicine"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "reproduktion",
+            "en": "Reproduction"
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/40304",
       "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "40304",
+      "hiddenLabelByLang": {"sv": "Annan veterinärmedicin"},
+      "isReplacedBy": [
+        {
+          "@id": "https://id.kb.se/term/ssif/40399",
+          "@annotation": {
+            "commentByLang": {"sv": "Ny kod"}
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/40399",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "40399",
       "prefLabelByLang": {
         "sv": "Annan veterinärmedicin",
         "en": "Other Veterinary Science"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/403"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/403"},
+      "scopeNoteByLang": {"sv": "Ny kod"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/404",
@@ -2591,7 +4056,23 @@
         "sv": "Växtbioteknologi",
         "en": "Plant Biotechnology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/404"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/404"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "skogsbioteknologi",
+            "en": "Forest Biotechnology"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "",
+            "en": ""
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/40402",
@@ -2602,7 +4083,37 @@
         "sv": "Genetik och förädling inom lantbruksvetenskap",
         "en": "Genetics and Breeding in Agricultural Sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/404"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/404"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "mikroorganismer",
+            "en": "Microorganisms"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "svampar",
+            "en": "Fungi"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "reproduktionsbioteknologi",
+            "en": "Reproductive Biotechnology"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "Cell-linjer och organioder",
+            "en": "Cell lines and Organoids"
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/405",
@@ -2618,13 +4129,11 @@
     {
       "@id": "https://id.kb.se/term/ssif/40501",
       "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "40501",
-      "prefLabelByLang": {
-        "sv": "Förnyelsebar bioenergi",
-        "en": "Renewable Bioenergy Research"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/405"}
+      "hiddenLabel": "Förnyelsebar bioenergi",
+      "isReplacedBy": [
+        {"@id": "https://id.kb.se/term/ssif/20904"}
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/40502",
@@ -2635,18 +4144,39 @@
         "sv": "Vilt- och fiskeförvaltning",
         "en": "Fish and Wildlife Management"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/405"}
-    },
-    {
-      "@id": "https://id.kb.se/term/ssif/40503",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
-      "code": "40503",
-      "prefLabelByLang": {
-        "sv": "Lantbrukets arbetsmiljö och säkerhet",
-        "en": "Agricultural Occupational Health and Safety"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/405"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/405"},
+      "scopeNoteByLang": {"sv": "Annan"},
+      "historyNoteByLang": {"sv": "Fiskpopulationsekologi ingick tidigare i Fisk- och akvakulturforskning 40107 (SSIF2011) men ingår nu i Vilt och fiskeförvaltning 40502 (SSIF2025)."},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "jakt",
+            "en": "Hunting"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "fisk och fiskeri",
+            "en": "Fishing and Fisheries"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "vilt- och fiskpopulationsekologi",
+            "en": "Game and Fishpopulation Ecology"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "",
+            "en": ""
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/40504",
@@ -2654,10 +4184,116 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "40504",
       "prefLabelByLang": {
-        "sv": "Miljö- och  naturvårdsvetenskap",
-        "en": "Environmental Sciences related to Agriculture and Land-use"
+        "sv": "Miljö- och naturvårdsvetenskap",
+        "en": "Environmental Sciences and Nature Conservation"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/405"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/405"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "biodiversitet",
+            "en": "Biodiversity"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "",
+            "en": ""
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "",
+            "en": ""
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/40503",
+      "@type": "Classification",
+      "code": "40503",
+      "hiddenLabel": "Lantbrukets arbetsmiljö och säkerhet",
+      "isReplacedBy": [
+        {"@id": "https://id.kb.se/term/ssif/40599"}
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/40108",
+      "@type": "Classification",
+      "code": "40108",
+      "hiddenLabelByLang": {"sv": "Landskapsarkitektur"},
+      "isReplacedBy": [
+        {
+          "@id": "https://id.kb.se/term/ssif/40505",
+          "@annotation": {
+            "commentByLang": {"sv": "Bytt forskningsämnesgrupp"}
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/40505",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "40505",
+      "prefLabelByLang": {
+        "sv": "Landskapsarkitektur",
+        "en": "Landscape Architecture"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/405"},
+      "scopeNoteByLang": {"sv": "Bytt forskningsämnesgrupp"},
+      "historyNoteByLang": {"sv": "Landskapsarkitektur 40505 (SSIF2025) ingick tidigare i Lantbruksvetenskap, skogsbruk och fiske 401 (SSIF2011)."},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "planering",
+            "en": "Planning"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "design",
+            "en": "Design"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "vård",
+            "en": "Management"
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/40506",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "40506",
+      "prefLabelByLang": {
+        "sv": "Jordbruksekonomi och landsbygdsutveckling",
+        "en": "Agricultural Economics and Management and Rural development"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/405"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/40507",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "40507",
+      "prefLabelByLang": {
+        "sv": "Miljöekonomi och förvaltning",
+        "en": "Environmental Economics and Management"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/405"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/40599",
@@ -2702,7 +4338,7 @@
       },
       "commentByLang": {
         "sv": "exklusive tillämpad psykologi",
-        "en": "excluding Applied Psychology"
+        "en": "Excluding Applied Psychology"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/501"}
     },
@@ -2715,7 +4351,23 @@
         "sv": "Tillämpad psykologi",
         "en": "Applied Psychology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/501"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/501"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "klinisk psykologi",
+            "en": "Clinical Psychology"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "psykoterapi",
+            "en": "Psychotherapy"
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/502",
@@ -2781,7 +4433,16 @@
         "sv": "Pedagogik",
         "en": "Pedagogy"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/503"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/503"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "special- och andra inriktningar av pedagogik",
+            "en": "Special Needs- and other orientations of Pedagogy"
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/50302",
@@ -2792,18 +4453,16 @@
         "sv": "Didaktik",
         "en": "Didactics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/503"}
-    },
-    {
-      "@id": "https://id.kb.se/term/ssif/50303",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
-      "code": "50303",
-      "prefLabelByLang": {
-        "sv": "Lärande",
-        "en": "Learning"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/503"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/503"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "allmän- och  ämnesdidaktik",
+            "en": "General and Subject Didactics"
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/50304",
@@ -2812,9 +4471,32 @@
       "code": "50304",
       "prefLabelByLang": {
         "sv": "Pedagogiskt arbete",
-        "en": "Pedagogical Work"
+        "en": "Educational Work"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/503"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/50303",
+      "@type": "Classification",
+      "code": "50303",
+      "hiddenLabel": "Lärande",
+      "isReplacedBy": [
+        {"@id": "https://id.kb.se/term/ssif/50301"},
+        {"@id": "https://id.kb.se/term/ssif/50302"},
+        {"@id": "https://id.kb.se/term/ssif/50399"}
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/50399",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "50399",
+      "prefLabelByLang": {
+        "sv": "Annan utbildningsvetenskaplig forskning",
+        "en": "Other Educational Sciences"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/503"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/504",
@@ -2837,10 +4519,22 @@
         "en": "Sociology"
       },
       "commentByLang": {
-        "sv": "exklusive socialt arbete, socialpsykologi och socialantropologi",
-        "en": "excluding Social Work, Social Psychology and Social Anthropology"
+        "sv": "exklusive socialt arbete, socialantropologi, demografi och kriminologi",
+        "en": "Excluding Social Work, Social Anthropology, Demography and Criminology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/504"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/504"},
+      "hiddenLabelByLang": {"sv": "Sociologi (exklusive socialt arbete, socialpsykologi och socialantropologi)"},
+      "scopeNoteByLang": {"sv": "Annan"},
+      "historyNoteByLang": {"sv": "Socialpsykologi  50403 (SSIF2011) ingår numera i Sociologi 50401 (SSIF2025). Demografi 50405 (SSIF2025) ingick tidigare i  Sociologi 50401 (SSIF2011) men utgör numera ett eget ämne."}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/50403",
+      "@type": "Classification",
+      "code": "50403",
+      "hiddenLabel": "Socialpsykologi",
+      "isReplacedBy": [
+        {"@id": "https://id.kb.se/term/ssif/50401"}
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/50402",
@@ -2854,17 +4548,6 @@
       "broader": {"@id": "https://id.kb.se/term/ssif/504"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50403",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
-      "code": "50403",
-      "prefLabelByLang": {
-        "sv": "Socialpsykologi",
-        "en": "Social Psychology"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/504"}
-    },
-    {
       "@id": "https://id.kb.se/term/ssif/50404",
       "@type": "Classification",
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
@@ -2874,6 +4557,45 @@
         "en": "Social Anthropology"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/504"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/50405",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "50405",
+      "prefLabelByLang": {
+        "sv": "Demografi",
+        "en": "Demography"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/504"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/50502",
+      "@type": "Classification",
+      "code": "50502",
+      "hiddenLabelByLang": {"sv": "Juridik och samhälle"},
+      "isReplacedBy": [
+        {
+          "@id": "https://id.kb.se/term/ssif/50406",
+          "@annotation": {
+            "commentByLang": {"sv": "Bytt forskningsämnesgrupp, Uppdelning av ämne"}
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/50406",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "50406",
+      "prefLabelByLang": {
+        "sv": "Kriminologi",
+        "en": "Criminology"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/504"},
+      "scopeNoteByLang": {"sv": "Bytt forskningsämnesgrupp, Uppdelning av ämne"},
+      "historyNoteByLang": {"sv": "Kriminologi 50406 (SSIF2025) ingick tidigare i Juridik och samhälle 50502 (SSIF2011) men utgör nu ett eget ämne."}
     },
     {
       "@id": "https://id.kb.se/term/ssif/505",
@@ -2895,22 +4617,23 @@
         "sv": "Juridik",
         "en": "Law"
       },
-      "commentByLang": {
-        "sv": "exklusive juridik och samhälle",
-        "en": "excluding Law and Society"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/505"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/505"},
+      "hiddenLabelByLang": {"sv": "Juridik (exklusive juridik och samhälle)"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50502",
+      "@id": "https://id.kb.se/term/ssif/50503",
       "@type": "Classification",
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
-      "code": "50502",
+      "code": "50503",
       "prefLabelByLang": {
-        "sv": "Juridik och samhälle",
-        "en": "Law and Society"
+        "sv": "Annan rättsvetenskaplig forskning",
+        "en": "Other Legal Research"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/505"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/505"},
+      "hiddenLabelByLang": {"sv": "Juridik och samhälle"},
+      "scopeNoteByLang": {"sv": "Annan"},
+      "historyNoteByLang": {"sv": "Kriminologi 50406 (SSIF2025) ingick tidigare i Juridik och samhälle 50502 (SSIF2011) men utgör nu ett eget ämne. Övrig forskning inom juridik och samhälle 50502 (SSIF2011) ingår numera i Annan rättsvetenskaplig forskning 50503(SSIF2025)."}
     },
     {
       "@id": "https://id.kb.se/term/ssif/506",
@@ -2933,32 +4656,49 @@
         "en": "Political Science"
       },
       "commentByLang": {
-        "sv": "exklusive studier av offentlig förvaltning och globaliseringsstudier",
-        "en": "excluding Public Administration Studies and Globalisation Studies"
+        "sv": "exklusive freds- och konfliktforskning",
+        "en": "Excluding Peace and Conflict Studies"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/506"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50602",
+      "@id": "https://id.kb.se/term/ssif/50901",
+      "@type": "Classification",
+      "code": "50901",
+      "hiddenLabel": "Tvärvetenskapliga studier inom samhällsvetenskap",
+      "isReplacedBy": [
+        {"@id": "https://id.kb.se/term/ssif/50999"}
+      ],
+      "related": [
+        {
+          "@id": "https://id.kb.se/term/ssif/50604",
+          "@annotation": {
+            "commentByLang": {"sv": "Uppdelning av ämne, bytt forskningsämnesgrupp"}
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/50604",
       "@type": "Classification",
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
-      "code": "50602",
+      "code": "50604",
       "prefLabelByLang": {
-        "sv": "Studier av offentlig förvaltning",
-        "en": "Public Administration Studies"
+        "sv": "Freds- och konfliktforskning",
+        "en": "Peace and Conflict Studies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/506"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/506"},
+      "scopeNoteByLang": {"sv": "Uppdelning av ämne, bytt forskningsämnesgrupp"},
+      "historyNoteByLang": {"sv": "Freds- och konfliktforskning 50604 (SSIF2025) ingick tidigare i Tvärvetenskapliga studier inom samhällsvetenskap 50901 (SSIF2011) men utgör nu ett eget ämne."}
     },
     {
       "@id": "https://id.kb.se/term/ssif/50603",
       "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "50603",
-      "prefLabelByLang": {
-        "sv": "Globaliseringsstudier",
-        "en": "Globalisation Studies"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/506"}
+      "hiddenLabel": "Globaliseringsstudier",
+      "isReplacedBy": [
+        {"@id": "https://id.kb.se/term/ssif/50703"}
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/507",
@@ -2994,15 +4734,39 @@
       "broader": {"@id": "https://id.kb.se/term/ssif/507"}
     },
     {
+      "@id": "https://id.kb.se/term/ssif/50703",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "50703",
+      "prefLabelByLang": {
+        "sv": "Andra geografiska studier",
+        "en": "Other Geographic Studies"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/507"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"},
+      "historyNoteByLang": {"sv": "Turism ingick tidigare i Ekonomisk geografi 50702 (SSIF2011) men ingår nu i Andra geografiska studier 50703 (SSIF2025)."},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "turism-, urban-, rurala och globala studier",
+            "en": "Tourism, Urban, Rural, and Global Studies"
+          }
+        }
+      ]
+    },
+    {
       "@id": "https://id.kb.se/term/ssif/508",
       "@type": "Classification",
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "508",
       "prefLabelByLang": {
-        "sv": "Medie- och kommunikationsvetenskap",
+        "sv": "Medie-, kommunikations-, och informationsvetenskaper",
         "en": "Media and Communications"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/5"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/5"},
+      "hiddenLabelByLang": {"sv": "Medie- och kommunikationsvetenskap"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/50801",
@@ -3010,32 +4774,31 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "50801",
       "prefLabelByLang": {
-        "sv": "Medievetenskap",
-        "en": "Media Studies"
+        "sv": "Medie- och kommunikationsvetenskap",
+        "en": "Media and Communication Studies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/508"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/508"},
+      "hiddenLabelByLang": {"sv": "Medievetenskap"},
+      "scopeNoteByLang": {"sv": "Sammanslagning av ämnen"},
+      "historyNoteByLang": {"sv": "Medievetenskap 50801 (SSIF2011) har slagits samman med Kommunikationsvetenskap 50802 (SSIF2011) och utgör tillsammans Medie- och kommunikationsvetenskap 50801 (SSIF2025)."}
     },
     {
       "@id": "https://id.kb.se/term/ssif/50802",
       "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "50802",
-      "prefLabelByLang": {
-        "sv": "Kommunikationsvetenskap",
-        "en": "Communication Studies"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/508"}
+      "hiddenLabel": "Kommunikationsvetenskap",
+      "isReplacedBy": [
+        {"@id": "https://id.kb.se/term/ssif/50801"}
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/50803",
       "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "50803",
-      "prefLabelByLang": {
-        "sv": "Mänsklig interaktion med IKT",
-        "en": "Human Aspects of ICT"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/508"}
+      "hiddenLabel": "Mänsklig interaktion med IKT",
+      "isReplacedBy": [
+        {"@id": "https://id.kb.se/term/ssif/50804"}
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/50804",
@@ -3046,7 +4809,18 @@
         "sv": "Systemvetenskap, informationssystem och informatik med samhällsvetenskaplig inriktning",
         "en": "Information Systems, Social aspects"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/508"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/508"},
+      "scopeNoteByLang": {"sv": "Sammanslagning av ämnen"},
+      "historyNoteByLang": {"sv": "Mänsklig interaktion med IKT 50803 (SSIF2011) ingår numera i Systemvetenskap, informationssystem och informatik med samhällsvetenskaplig inriktning 50804 (SSIF2025)."},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "mänsklig interaktion med IKT",
+            "en": "Human Aspects of ICT"
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/50805",
@@ -3054,7 +4828,7 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "50805",
       "prefLabelByLang": {
-        "sv": "Biblioteks- och informationsvetenskap",
+        "sv": "Biblioteks-och informationsvetenskap",
         "en": "Information Studies"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/508"}
@@ -3069,17 +4843,6 @@
         "en": "Other Social Sciences"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/5"}
-    },
-    {
-      "@id": "https://id.kb.se/term/ssif/50901",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
-      "code": "50901",
-      "prefLabelByLang": {
-        "sv": "Tvärvetenskapliga studier inom samhällsvetenskap",
-        "en": "Social Sciences Interdisciplinary"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/509"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/50902",
@@ -3114,6 +4877,117 @@
       },
       "altLabelByLang": {"sv": "IMER"},
       "broader": {"@id": "https://id.kb.se/term/ssif/509"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/50602",
+      "@type": "Classification",
+      "code": "50602",
+      "hiddenLabelByLang": {"sv": "Studier av offentlig förvaltning"},
+      "isReplacedBy": [
+        {
+          "@id": "https://id.kb.se/term/ssif/50905",
+          "@annotation": {
+            "commentByLang": {"sv": "Bytt forskningsämnesgrupp"}
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/50905",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "50905",
+      "prefLabelByLang": {
+        "sv": "Studier av offentlig förvaltning",
+        "en": "Public Administration Studies"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/509"},
+      "scopeNoteByLang": {"sv": "Bytt forskningsämnesgrupp"},
+      "historyNoteByLang": {"sv": "Studier av offentlig förvaltning 50905 (SSIF2025) ingick tidigare i Statsvetenskap 506 (SSIF2011)."}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/50906",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "50906",
+      "prefLabelByLang": {
+        "sv": "Utvecklingsstudier",
+        "en": "Development Studies"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/509"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/50907",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "50907",
+      "prefLabelByLang": {
+        "sv": "Statistik inom samhällsvetenskap",
+        "en": "Statistics in Social Sciences"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/509"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/50908",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "50908",
+      "prefLabelByLang": {
+        "sv": "Samhällsvetenskapliga hälso- och koststudier",
+        "en": "Health and Diet Studies in Social Sciences"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/509"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/50909",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "50909",
+      "prefLabelByLang": {
+        "sv": "Miljövetenskapliga studier inom samhällsvetenskap",
+        "en": "Environmental Studies in Social Sciences"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/509"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/50910",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "50910",
+      "prefLabelByLang": {
+        "sv": "Barn- och ungdomsvetenskap",
+        "en": "Child and Youth Studies"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/509"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/50911",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "50911",
+      "prefLabelByLang": {
+        "sv": "Krigs-, kris-, säkerhetsvetenskaper",
+        "en": "War, Crisis, and Security Studies"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/509"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/50912",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "50912",
+      "prefLabelByLang": {
+        "sv": "Teknik och samhälle",
+        "en": "Science and Technology Studies"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/509"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/50999",
@@ -3164,10 +5038,12 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "60102",
       "prefLabelByLang": {
-        "sv": "Teknikhistoria",
-        "en": "History of Technology"
+        "sv": "Teknik- och miljöhistoria",
+        "en": "Technology and Environmental History"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/601"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/601"},
+      "hiddenLabelByLang": {"sv": "Teknikhistoria"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/60103",
@@ -3179,6 +5055,60 @@
         "en": "Archaeology"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/601"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/60305",
+      "@type": "Classification",
+      "code": "60305",
+      "hiddenLabelByLang": {"sv": "Idé- och lärdomshistoria"},
+      "isReplacedBy": [
+        {
+          "@id": "https://id.kb.se/term/ssif/60104",
+          "@annotation": {
+            "commentByLang": {"sv": "Bytt forskningsämnesgrupp"}
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/60104",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "60104",
+      "prefLabelByLang": {
+        "sv": "Idé- och lärdomshistoria",
+        "en": "History of Science and Ideas"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/601"},
+      "scopeNoteByLang": {"sv": "Bytt forskningsämnesgrupp"},
+      "historyNoteByLang": {"sv": "Idé- och lärdomshistoria 60104 (SSIF2025) ingick tidigare i Filosofi, etik och religion 603 (SSIF2011)."}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/60501",
+      "@type": "Classification",
+      "code": "60501",
+      "hiddenLabelByLang": {"sv": "Antikvetenskap"},
+      "isReplacedBy": [
+        {
+          "@id": "https://id.kb.se/term/ssif/60105",
+          "@annotation": {
+            "commentByLang": {"sv": "Bytt forskningsämnesgrupp"}
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/60105",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "60105",
+      "prefLabelByLang": {
+        "sv": "Antikvetenskap",
+        "en": "Classical Archaeology and Ancient History"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/601"},
+      "scopeNoteByLang": {"sv": "Bytt forskningsämnesgrupp"},
+      "historyNoteByLang": {"sv": "Antikvetenskap 60105 (SSIF2025) ingick tidigare i Annan humaniora 605 (SSIF2011)."}
     },
     {
       "@id": "https://id.kb.se/term/ssif/602",
@@ -3198,7 +5128,7 @@
       "code": "60201",
       "prefLabelByLang": {
         "sv": "Jämförande språkvetenskap och allmän lingvistik",
-        "en": "General Language Studies and Linguistics"
+        "en": "Comparative Language Studies and Linguistics"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/602"}
     },
@@ -3209,7 +5139,7 @@
       "code": "60202",
       "prefLabelByLang": {
         "sv": "Studier av enskilda språk",
-        "en": "Specific Languages"
+        "en": "Studies of Specific Languages"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/602"}
     },
@@ -3220,9 +5150,18 @@
       "code": "60203",
       "prefLabelByLang": {
         "sv": "Litteraturvetenskap",
-        "en": "General Literary Studies"
+        "en": "General Literary studies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/602"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/602"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "litteraturteori",
+            "en": "Literary Theory"
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/60204",
@@ -3231,9 +5170,54 @@
       "code": "60204",
       "prefLabelByLang": {
         "sv": "Litteraturstudier",
-        "en": "Specific Literatures"
+        "en": "Studies of Specific Literatures"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/602"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/602"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "litteraturer från särskilda språkområden",
+            "en": "Literature from specific Language areas"
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/60205",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "60205",
+      "prefLabelByLang": {
+        "sv": "Filologi",
+        "en": "Philology"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/602"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/60206",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "60206",
+      "prefLabelByLang": {
+        "sv": "Översättningsvetenskap",
+        "en": "Translation Studies"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/602"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/60207",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "60207",
+      "prefLabelByLang": {
+        "sv": "Retorik",
+        "en": "Rhetoric"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/602"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/603",
@@ -3277,7 +5261,44 @@
         "sv": "Religionsvetenskap",
         "en": "Religious Studies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/603"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/603"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "religionsbeteendevetenskap",
+            "en": "Social Sciences of Religions"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "tros- och livsåskådningsvetenskap/systematisk teologi",
+            "en": "Studies in Faiths and Ideologies/Systematic Theology"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "bibelvetenskap",
+            "en": "Biblical Studies"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "kyrkovetenskap",
+            "en": "Ecclesiology/ Practical Theology"
+          }
+        },
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "kyrkohistoria",
+            "en": "Church History"
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/60304",
@@ -3291,15 +5312,16 @@
       "broader": {"@id": "https://id.kb.se/term/ssif/603"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60305",
+      "@id": "https://id.kb.se/term/ssif/60306",
       "@type": "Classification",
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
-      "code": "60305",
+      "code": "60306",
       "prefLabelByLang": {
-        "sv": "Idé- och lärdomshistoria",
-        "en": "History of Ideas"
+        "sv": "Estetik",
+        "en": "Aesthetics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/603"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/603"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/604",
@@ -3313,72 +5335,6 @@
       "broader": {"@id": "https://id.kb.se/term/ssif/6"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60401",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
-      "code": "60401",
-      "prefLabelByLang": {
-        "sv": "Bildkonst",
-        "en": "Visual Arts"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/604"}
-    },
-    {
-      "@id": "https://id.kb.se/term/ssif/60402",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
-      "code": "60402",
-      "prefLabelByLang": {
-        "sv": "Musik",
-        "en": "Music"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/604"}
-    },
-    {
-      "@id": "https://id.kb.se/term/ssif/60403",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
-      "code": "60403",
-      "prefLabelByLang": {
-        "sv": "Litterär gestaltning",
-        "en": "Literary Composition"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/604"}
-    },
-    {
-      "@id": "https://id.kb.se/term/ssif/60404",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
-      "code": "60404",
-      "prefLabelByLang": {
-        "sv": "Scenkonst",
-        "en": "Performing Arts"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/604"}
-    },
-    {
-      "@id": "https://id.kb.se/term/ssif/60405",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
-      "code": "60405",
-      "prefLabelByLang": {
-        "sv": "Arkitektur",
-        "en": "Architecture"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/604"}
-    },
-    {
-      "@id": "https://id.kb.se/term/ssif/60406",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
-      "code": "60406",
-      "prefLabelByLang": {
-        "sv": "Design",
-        "en": "Design"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/604"}
-    },
-    {
       "@id": "https://id.kb.se/term/ssif/60407",
       "@type": "Classification",
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
@@ -3387,7 +5343,16 @@
         "sv": "Konstvetenskap",
         "en": "Art History"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/604"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/604"},
+      "narrower": [
+        {
+          "@type": "Concept",
+          "prefLabelByLang": {
+            "sv": "textil-  och modevetenskap",
+            "en": "Textile and Fashion Design Studies"
+          }
+        }
+      ]
     },
     {
       "@id": "https://id.kb.se/term/ssif/60408",
@@ -3418,9 +5383,188 @@
       "code": "60410",
       "prefLabelByLang": {
         "sv": "Filmvetenskap",
-        "en": "Studies on Film"
+        "en": "Film Studies"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/604"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/60411",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "60411",
+      "prefLabelByLang": {
+        "sv": "Fri Konst",
+        "en": "Visual Arts"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/604"},
+      "hiddenLabelByLang": {"sv": "Bildkonst"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/60402",
+      "@type": "Classification",
+      "code": "60402",
+      "hiddenLabelByLang": {"sv": "Musik"},
+      "isReplacedBy": [
+        {
+          "@id": "https://id.kb.se/term/ssif/60412",
+          "@annotation": {
+            "commentByLang": {"sv": "Ny kod"}
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/60412",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "60412",
+      "prefLabelByLang": {
+        "sv": "Musik",
+        "en": "Music"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/604"},
+      "scopeNoteByLang": {"sv": "Ny kod"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/60403",
+      "@type": "Classification",
+      "code": "60403",
+      "hiddenLabelByLang": {"sv": "Litterär gestaltning"},
+      "isReplacedBy": [
+        {
+          "@id": "https://id.kb.se/term/ssif/60413",
+          "@annotation": {
+            "commentByLang": {"sv": "Ny kod"}
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/60413",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "60413",
+      "prefLabelByLang": {
+        "sv": "Litterär gestaltning",
+        "en": "Literary Composition"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/604"},
+      "scopeNoteByLang": {"sv": "Ny kod"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/60404",
+      "@type": "Classification",
+      "code": "60404",
+      "hiddenLabelByLang": {"sv": "Scenkonst"},
+      "isReplacedBy": [
+        {
+          "@id": "https://id.kb.se/term/ssif/60414",
+          "@annotation": {
+            "commentByLang": {"sv": "Ny kod"}
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/60414",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "60414",
+      "prefLabelByLang": {
+        "sv": "Scenkonst",
+        "en": "Performing Arts"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/604"},
+      "scopeNoteByLang": {"sv": "Ny kod"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/60405",
+      "@type": "Classification",
+      "code": "60405",
+      "hiddenLabelByLang": {"sv": "Arkitektur"},
+      "isReplacedBy": [
+        {
+          "@id": "https://id.kb.se/term/ssif/60415",
+          "@annotation": {
+            "commentByLang": {"sv": "Ny kod"}
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/60415",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "60415",
+      "prefLabelByLang": {
+        "sv": "Arkitektur",
+        "en": "Architecture"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/604"},
+      "scopeNoteByLang": {"sv": "Ny kod"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/60406",
+      "@type": "Classification",
+      "code": "60406",
+      "hiddenLabelByLang": {"sv": "Design"},
+      "isReplacedBy": [
+        {
+          "@id": "https://id.kb.se/term/ssif/60416",
+          "@annotation": {
+            "commentByLang": {"sv": "Ny kod"}
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/60416",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "60416",
+      "prefLabelByLang": {
+        "sv": "Design",
+        "en": "Design"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/604"},
+      "scopeNoteByLang": {"sv": "Ny kod"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/60417",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "60417",
+      "prefLabelByLang": {
+        "sv": "Film",
+        "en": "Film"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/604"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/60418",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "60418",
+      "prefLabelByLang": {
+        "sv": "Konsthantverk",
+        "en": "Crafts"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/604"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/60419",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "60419",
+      "prefLabelByLang": {
+        "sv": "Fotografi",
+        "en": "Photography"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/604"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/605",
@@ -3428,21 +5572,12 @@
       "inScheme": {"@id": "https://id.kb.se/term/ssif"},
       "code": "605",
       "prefLabelByLang": {
-        "sv": "Annan humaniora",
+        "sv": "Annan humaniora och konst",
         "en": "Other Humanities"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/6"}
-    },
-    {
-      "@id": "https://id.kb.se/term/ssif/60501",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
-      "code": "60501",
-      "prefLabelByLang": {
-        "sv": "Antikvetenskap",
-        "en": "Classical Archaeology and Ancient History"
-      },
-      "broader": {"@id": "https://id.kb.se/term/ssif/605"}
+      "broader": {"@id": "https://id.kb.se/term/ssif/6"},
+      "hiddenLabelByLang": {"sv": "Annan humaniora"},
+      "scopeNoteByLang": {"sv": "Bytt benämning"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/60502",
@@ -3465,6 +5600,18 @@
         "en": "Ethnology"
       },
       "broader": {"@id": "https://id.kb.se/term/ssif/605"}
+    },
+    {
+      "@id": "https://id.kb.se/term/ssif/60504",
+      "@type": "Classification",
+      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "code": "60504",
+      "prefLabelByLang": {
+        "sv": "Tvärdiciplinära studier i humaniora och konst",
+        "en": "Interdisciplinary Studies in Humanities and Arts"
+      },
+      "broader": {"@id": "https://id.kb.se/term/ssif/605"},
+      "scopeNoteByLang": {"sv": "Nytt ämne"}
     },
     {
       "@id": "https://id.kb.se/term/ssif/60599",

--- a/resources/ssif.jsonld
+++ b/resources/ssif.jsonld
@@ -1,6 +1,10 @@
 {
   "@context": {
-    "@vocab": "https://id.kb.se/vocab/",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "labelByLang": {
+      "@id": "rdfs:label",
+      "@container": "@language"
+    },
     "prefLabelByLang": {
       "@id": "prefLabel",
       "@container": "@language"
@@ -10,7 +14,7 @@
       "@container": "@language"
     },
     "commentByLang": {
-      "@id": "comment",
+      "@id": "rdfs:comment",
       "@container": "@language"
     },
     "hiddenLabelByLang": {
@@ -24,13 +28,27 @@
     "historyNoteByLang": {
       "@id": "historyNote",
       "@container": "@language"
-    }
+    },
+    "@vocab": "http://www.w3.org/2004/02/skos/core#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "dct": "http://purl.org/dc/terms/",
+    "date": "dct:date",
+    "ratio": "rdf:value",
+    "code": "notation",
+    "isReplacedBy": "dct:isReplacedBy"
   },
   "@graph": [
     {
-      "@id": "https://id.kb.se/term/ssif/1",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF",
+      "@type": "ConceptScheme",
+      "code": "SSIF",
+      "prefLabelByLang": {"sv": "Standard för svensk indelning av forskningsämnen"}
+    },
+    {
+      "@id": "https://begrepp.uka.se/SSIF/1",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "1",
       "prefLabelByLang": {
         "sv": "Naturvetenskap",
@@ -38,142 +56,141 @@
       }
     },
     {
-      "@id": "https://id.kb.se/term/ssif/101",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/101",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "101",
       "prefLabelByLang": {
         "sv": "Matematik",
         "en": "Mathematical sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/1"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/1"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10101",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10101",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10101",
       "prefLabelByLang": {
         "sv": "Matematisk analys",
         "en": "Mathematical Analysis"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/101"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/101"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10102",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10102",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10102",
       "prefLabelByLang": {
         "sv": "Geometri",
         "en": "Geometry"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/101"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/101"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10103",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10103",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10103",
       "prefLabelByLang": {
         "sv": "Algebra och logik",
         "en": "Algebra and Logic"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/101"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/101"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10104",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10104",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10104",
       "prefLabelByLang": {
         "sv": "Diskret matematik",
         "en": "Discrete Mathematics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/101"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/101"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10105",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10105",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10105",
       "prefLabelByLang": {
         "sv": "Beräkningsmatematik",
         "en": "Computational Mathematics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/101"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/101"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10106",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10106",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10106",
       "prefLabelByLang": {
         "sv": "Sannolikhetsteori och statistik",
         "en": "Probability Theory and Statistics"
       },
-      "commentByLang": {
+      "scopeNoteByLang": {
         "sv": "Statistik med medicinska aspekter under 30118 och samhällsvetenskapliga aspekter under 50907",
         "en": "Statistics with medical aspects at 30118 and with social aspects at 50907"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/101"},
-      "scopeNoteByLang": {"sv": "Annan"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/101"},
       "historyNoteByLang": {"sv": "Numera finns även ämnena medicinsk biostatistik 30118 (SSIF2025) som ingår i Medicinska och farmaceutiska grundvetenskaper 301 och Statistik inom samhällsvetenskap 50907 (SSIF2025) som ingår i Annan samhällsvetenskap 509."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10199",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10199",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10199",
       "prefLabelByLang": {
         "sv": "Annan matematik",
         "en": "Other Mathematics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/101"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/101"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/102",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/102",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "102",
       "prefLabelByLang": {
         "sv": "Data- och informationsvetenskap",
         "en": "Computer and Information Sciences"
       },
       "altLabelByLang": {"sv": "Datateknik"},
-      "broader": {"@id": "https://id.kb.se/term/ssif/1"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/1"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10201",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10201",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10201",
       "prefLabelByLang": {
         "sv": "Datavetenskap",
         "en": "Computer Sciences"
       },
       "altLabelByLang": {"sv": "datalogi"},
-      "broader": {"@id": "https://id.kb.se/term/ssif/102"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/102"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10202",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10202",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10202",
       "prefLabelByLang": {
         "sv": "Systemvetenskap, informationssystem och informatik",
         "en": "Information Systems"
       },
-      "commentByLang": {
+      "scopeNoteByLang": {
         "sv": "samhällsvetenskapliga aspekter under 50804",
         "en": "Social aspects at 50804"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/102"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/102"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10203",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10203",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10203",
       "prefLabelByLang": {
         "sv": "Bioinformatik",
@@ -183,205 +200,201 @@
         "sv": "beräkningsbiologi",
         "en": "Computational Biology"
       },
-      "commentByLang": {
+      "scopeNoteByLang": {
         "sv": "tillämpningar under 10610",
         "en": "Applications at 10610"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/102"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/102"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10204",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10204",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10204",
       "prefLabelByLang": {
         "sv": "Människa-datorinteraktion",
         "en": "Human Computer Interaction"
       },
       "altLabelByLang": {"sv": "interaktionsdesign"},
-      "commentByLang": {
+      "scopeNoteByLang": {
         "sv": "Samhällsvetenskapliga aspekter under 50804",
         "en": "Social aspects at 50804"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/102"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/102"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10205",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10205",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10205",
       "prefLabelByLang": {
         "sv": "Programvaruteknik",
         "en": "Software Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/102"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/102"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10206",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10206",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10206",
       "prefLabelByLang": {
         "sv": "Datorteknik",
         "en": "Computer Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/102"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/102"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10207",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10207",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10207",
       "prefLabelByLang": {
         "sv": "Datorgrafik och datorseende",
         "en": "Computer graphics and computer vision"
       },
-      "commentByLang": {
+      "scopeNoteByLang": {
         "sv": "systemtekniska aspekter under 20208",
         "en": "System engineering aspects at 20208"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/102"},
-      "hiddenLabelByLang": {"sv": "Datorseende och robotik (autonoma system)"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/102"},
+      "hiddenLabelByLang": {"sv": "Datorseende och robotik (autonoma system)"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10208",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10208",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10208",
       "prefLabelByLang": {
         "sv": "Språkbehandling och datorlingvistik",
         "en": "Natural Language Processing"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/102"},
-      "hiddenLabelByLang": {"sv": "Språkteknologi (språkvetenskaplig databehandling)"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/102"},
+      "hiddenLabelByLang": {"sv": "Språkteknologi (språkvetenskaplig databehandling)"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10209",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/10209",
+      "@type": "Concept",
       "code": "10209",
-      "hiddenLabel": "Medieteknik",
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Medieteknik"},
       "isReplacedBy": [
-        {"@id": "https://id.kb.se/term/ssif/10202"},
-        {"@id": "https://id.kb.se/term/ssif/10204"}
-      ]
+        {"@id": "https://begrepp.uka.se/SSIF/10202"},
+        {"@id": "https://begrepp.uka.se/SSIF/10204"}
+      ],
+      "historyNoteByLang": {"sv": "Kan exempelvis ingå i Systemvetenskap, informationssystem och informatik 10202 (SSIF2025) eller Människa-datorinteraktion (interaktionsdesign) 10204 (SSIF2025) beroende på forskningens/utbildningens karraktär."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10210",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10210",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10210",
       "prefLabelByLang": {
         "sv": "Artificiell intelligens",
         "en": "Artificial Intelligence"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/102"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/102"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10211",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10211",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10211",
       "prefLabelByLang": {
         "sv": "Säkerhet, integritet och kryptologi",
         "en": "Security, Privacy and Cryptography"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/102"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/102"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10212",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10212",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10212",
       "prefLabelByLang": {
         "sv": "Algoritmer",
         "en": "Algorithms"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/102"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/102"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10213",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10213",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10213",
       "prefLabelByLang": {
         "sv": "Formella metoder",
         "en": "Formal Methods"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/102"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/102"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10214",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10214",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10214",
       "prefLabelByLang": {
         "sv": "Nätverks-, parallell- och distribuerad beräkning",
         "en": "Networked, Parallel and Distributed Computing"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/102"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/102"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10299",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10299",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10299",
       "prefLabelByLang": {
         "sv": "Annan data- och informationsvetenskap",
         "en": "Other Computer and Information Science"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/102"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/102"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/103",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/103",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "103",
       "prefLabelByLang": {
         "sv": "Fysik",
         "en": "Physical Sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/1"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/1"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10301",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10301",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10301",
       "prefLabelByLang": {
         "sv": "Subatomär fysik",
         "en": "Subatomic Physics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/103"},
-      "scopeNoteByLang": {"sv": "Sammanslagning av ämnen"},
-      "historyNoteByLang": {"sv": "Acceleratorfysik och instrumentering 10306 (SSIF2011) ingår numera i Subatomär fysik 10301 (SSIF2025)."},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/103"},
       "narrower": [
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "fält- och partikelfysik",
             "en": "Particle and Field Physics"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "fält- och partikelfysik"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "astropartikelfysik",
             "en": "Astroparticle Physics"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "astropartikelfysik"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "kärnfysik",
             "en": "Nuclear Physics"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "kärnfysik"}
         },
         {
           "@type": "Concept",
@@ -390,63 +403,63 @@
             "en": "Accelerator Physics"
           }
         }
-      ]
+      ],
+      "historyNoteByLang": {"sv": "Acceleratorfysik och instrumentering 10306 (SSIF2011) ingår numera i Subatomär fysik 10301 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10302",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10302",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10302",
       "prefLabelByLang": {
         "sv": "Atom- och molekylfysik och optik",
         "en": "Atom and Molecular Physics and Optics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/103"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/103"},
       "narrower": [
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "kemisk fysik",
             "en": "Chemical Physics"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "kemisk fysik"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "kvantoptik",
             "en": "Quantum Optics"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "laseroptik"}
         },
         {
           "@type": "Concept",
-          "prefLabelByLang": {
-            "sv": "",
-            "en": ""
-          }
+          "hiddenLabelByLang": {"sv": "kvantoptik"}
         }
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10303",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10303",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10303",
       "prefLabelByLang": {
         "sv": "Fusion, plasma och rymdfysik",
         "en": "Fusion, Plasma and Space Physics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/103"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/103"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10304",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10304",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10304",
       "prefLabelByLang": {
         "sv": "Den kondenserade materiens fysik",
         "en": "Condensed Matter Physics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/103"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/103"},
       "narrower": [
         {
           "@type": "Concept",
@@ -465,149 +478,146 @@
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10305",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10305",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10305",
       "prefLabelByLang": {
         "sv": "Astronomi, astrofysik och kosmologi",
         "en": "Astronomy, Astrophysics, and Cosmology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/103"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/103"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10306",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/10306",
+      "@type": "Concept",
       "code": "10306",
-      "hiddenLabel": "Acceleratorfysik och instrumentering",
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Acceleratorfysik och instrumentering"},
       "isReplacedBy": [
-        {"@id": "https://id.kb.se/term/ssif/10301"}
-      ]
+        {"@id": "https://begrepp.uka.se/SSIF/10301"}
+      ],
+      "historyNoteByLang": {"sv": "Acceleratorfysik och instrumentering 10306 (SSIF2011) ingår numera i Subatomär fysik 10301 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10603",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/10603",
+      "@type": "Concept",
       "code": "10603",
-      "hiddenLabelByLang": {"sv": "Biofysik"},
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Biofysik"},
       "isReplacedBy": [
-        {
-          "@id": "https://id.kb.se/term/ssif/10307",
-          "@annotation": {
-            "commentByLang": {"sv": "Bytt forskningsämnesgrupp"}
-          }
-        }
+        {"@id": "https://begrepp.uka.se/SSIF/10307"}
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10307",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10307",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10307",
       "prefLabelByLang": {
         "sv": "Biofysik",
         "en": "Biophysics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/103"},
-      "scopeNoteByLang": {"sv": "Bytt forskningsämnesgrupp"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/103"},
       "historyNoteByLang": {"sv": "Biofysik 10307 (SSIF2025) ingick tidigare i Biologi 106 (SSIF2011)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10308",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10308",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10308",
       "prefLabelByLang": {
         "sv": "Statistisk fysik och komplexa system",
         "en": "Statistical physics and complex systems"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/103"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/103"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10399",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10399",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10399",
       "prefLabelByLang": {
         "sv": "Annan fysik",
         "en": "Other Physics Topics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/103"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/103"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/104",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/104",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "104",
       "prefLabelByLang": {
         "sv": "Kemi",
         "en": "Chemical Sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/1"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/1"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10401",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10401",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10401",
       "prefLabelByLang": {
         "sv": "Analytisk kemi",
         "en": "Analytical Chemistry"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/104"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/104"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10402",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10402",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10402",
       "prefLabelByLang": {
         "sv": "Fysikalisk kemi",
         "en": "Physical Chemistry"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/104"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/104"},
       "narrower": [
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "yt- och kolloidkemi",
             "en": "Surface- and Colloid Chemistry"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "kolloidkemi"}
         }
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10403",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10403",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10403",
       "prefLabelByLang": {
         "sv": "Materialkemi",
         "en": "Materials Chemistry"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/104"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/104"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10404",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10404",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10404",
       "prefLabelByLang": {
         "sv": "Oorganisk kemi",
         "en": "Inorganic Chemistry"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/104"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/104"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10405",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10405",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10405",
       "prefLabelByLang": {
         "sv": "Organisk kemi",
         "en": "Organic Chemistry"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/104"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/104"},
       "narrower": [
         {
           "@type": "Concept",
@@ -619,232 +629,221 @@
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10406",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10406",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10406",
       "prefLabelByLang": {
         "sv": "Polymerkemi",
         "en": "Polymer Chemistry"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/104"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/104"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10407",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10407",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10407",
       "prefLabelByLang": {
         "sv": "Teoretisk kemi",
         "en": "Theoretical Chemistry"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/104"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/104"},
       "narrower": [
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "beräkningskemi",
             "en": "Computational Chemistry"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "kvantkemi"}
         }
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10602",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/10602",
+      "@type": "Concept",
       "code": "10602",
-      "hiddenLabelByLang": {"sv": "Biokemi och molekylärbiologi"},
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Biokemi och molekylärbiologi"},
       "isReplacedBy": [
-        {
-          "@id": "https://id.kb.se/term/ssif/10408",
-          "@annotation": {
-            "commentByLang": {"sv": "Bytt forskningsämnesgrupp, Uppdelning av ämne"}
-          }
-        },
-        {
-          "@id": "https://id.kb.se/term/ssif/10616",
-          "@annotation": {
-            "commentByLang": {"sv": "Uppdelning av ämne"}
-          }
-        }
+        {"@id": "https://begrepp.uka.se/SSIF/10408"},
+        {"@id": "https://begrepp.uka.se/SSIF/10616"}
+      ],
+      "narrowMatch": [
+        {"@id": "https://begrepp.uka.se/SSIF/10616"}
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10408",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10408",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10408",
       "prefLabelByLang": {
         "sv": "Biokemi",
         "en": "Biochemistry"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/104"},
-      "scopeNoteByLang": {"sv": "Bytt forskningsämnesgrupp, Uppdelning av ämne"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/104"},
       "historyNoteByLang": {"sv": "Biokemi och molekylärbiologi 10602 (SSIF2011) har delats upp i två ämnen. Biokemi 10408 (SSIF 2025) ingår nu i Kemi 104 medan Molekylärbiologi 10616 (SSIF2025) fortsatt ingår i Biologi 106."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10499",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10499",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10499",
       "prefLabelByLang": {
         "sv": "Annan kemi",
         "en": "Other Chemistry Topics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/104"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/104"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/105",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/105",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "105",
       "prefLabelByLang": {
         "sv": "Geovetenskap och relaterad miljövetenskap",
         "en": "Earth and Related Environmental Sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/1"},
-      "hiddenLabelByLang": {"sv": "Geovetenskap och miljövetenskap"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/1"},
+      "hiddenLabelByLang": {"sv": "Geovetenskap och miljövetenskap"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10501",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10501",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10501",
       "prefLabelByLang": {
         "sv": "Klimatvetenskap",
         "en": "Climate Science"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/105"},
-      "hiddenLabelByLang": {"sv": "Klimatforskning"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/105"},
+      "hiddenLabelByLang": {"sv": "Klimatforskning"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10502",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10502",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10502",
       "prefLabelByLang": {
         "sv": "Miljövetenskap",
         "en": "Environmental Sciences"
       },
-      "commentByLang": {
+      "scopeNoteByLang": {
         "sv": "Samhällsvetenskapliga aspekter under 50909 och lantbruksvetenskapliga under 40504",
         "en": "Social aspects at 50909 and agricultural at 40504"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/105"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/105"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10503",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10503",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10503",
       "prefLabelByLang": {
         "sv": "Multidisciplinär geovetenskap",
         "en": "Multidisciplinary Geosciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/105"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/105"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10504",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10504",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10504",
       "prefLabelByLang": {
         "sv": "Geologi",
         "en": "Geology"
       },
-      "commentByLang": {
+      "scopeNoteByLang": {
         "sv": "Geoteknik och teknisk geologi under 20106",
         "en": "Geotechnical Engineering and Engineering Geology at 20106"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/105"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/105"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10505",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10505",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10505",
       "prefLabelByLang": {
         "sv": "Geofysik",
         "en": "Geophysics"
       },
-      "commentByLang": {
+      "scopeNoteByLang": {
         "sv": "Tillämningar med jordobservationsteknik under 20703",
         "en": "Applications with Earth Observation at 20703"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/105"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/105"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10506",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10506",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10506",
       "prefLabelByLang": {
         "sv": "Geokemi",
         "en": "Geochemistry"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/105"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/105"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10507",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10507",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10507",
       "prefLabelByLang": {
         "sv": "Naturgeografi",
         "en": "Physical Geography"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/105"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/105"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10508",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10508",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10508",
       "prefLabelByLang": {
         "sv": "Meteorologi och atmosfärsvetenskap",
         "en": "Meteorology and Atmospheric Sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/105"},
-      "hiddenLabelByLang": {"sv": "Meteorologi och atmosfärforskning"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/105"},
+      "hiddenLabelByLang": {"sv": "Meteorologi och atmosfärforskning"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10509",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10509",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10509",
       "prefLabelByLang": {
         "sv": "Oceanografi, hydrologi och vattenresurser",
         "en": "Oceanography, Hydrology and Water Resources"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/105"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/105"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10510",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10510",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10510",
       "prefLabelByLang": {
         "sv": "Paleontologi och paleoekologi",
         "en": "Palaeontology and Palaeoecology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/105"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/105"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10599",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10599",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10599",
       "prefLabelByLang": {
         "sv": "Annan geovetenskap",
         "en": "Other Earth Sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/105"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/105"},
       "hiddenLabelByLang": {"sv": "Annan geovetenskap och miljövetenskap"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"},
       "narrower": [
         {
           "@type": "Concept",
@@ -856,127 +855,125 @@
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/106",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/106",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "106",
       "prefLabelByLang": {
         "sv": "Biologi",
         "en": "Biological Sciences"
       },
-      "commentByLang": {
+      "scopeNoteByLang": {
         "sv": "Medicinska tillämpningar under 3 och lantbruksvetenskapliga under 4",
         "en": "Medical aspects at 3 and agricultural at 4"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/1"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/1"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10601",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10601",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10601",
       "prefLabelByLang": {
         "sv": "Strukturbiologi",
         "en": "Structural Biology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/106"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/106"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10604",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10604",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10604",
       "prefLabelByLang": {
         "sv": "Cellbiologi",
         "en": "Cell Biology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/106"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/106"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10605",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10605",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10605",
       "prefLabelByLang": {
         "sv": "Immunologi",
         "en": "Immunology"
       },
-      "commentByLang": {
+      "scopeNoteByLang": {
         "sv": "medicinska aspekter under 30110 och lantbruksvetenskapliga under 40302",
         "en": "Medical aspects at 30110 and agricultural at 40302"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/106"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/106"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10606",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10606",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10606",
       "prefLabelByLang": {
         "sv": "Mikrobiologi",
         "en": "Microbiology"
       },
-      "commentByLang": {
+      "scopeNoteByLang": {
         "sv": "medicinska aspekter under 30109 och lantbruksvetenskapliga under 40302",
         "en": "Medical aspects at 30109 and agricultural at 40302"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/106"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/106"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10607",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10607",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10607",
       "prefLabelByLang": {
         "sv": "Botanik",
         "en": "Botany"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/106"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/106"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10608",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10608",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10608",
       "prefLabelByLang": {
         "sv": "Zoologi",
         "en": "Zoology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/106"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/106"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10609",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10609",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10609",
       "prefLabelByLang": {
         "sv": "Genetik och genomik",
         "en": "Genetics and Genomics"
       },
-      "commentByLang": {
+      "scopeNoteByLang": {
         "sv": "medicinska aspekter under 30107 och lantbruksvetenskapliga under 40402",
         "en": "Medical aspects at 30107 and agricultural at 40402"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/106"},
-      "hiddenLabelByLang": {"sv": "Genetik (medicinsk under 30107 och lantbruksvetenskaplig under 40402)"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/106"},
+      "hiddenLabelByLang": {"sv": "Genetik (medicinsk under 30107 och lantbruksvetenskaplig under 40402)"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10610",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10610",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10610",
       "prefLabelByLang": {
         "sv": "Bioinformatik och beräkningsbiologi",
         "en": "Bioinformatics and Computational Biology"
       },
-      "commentByLang": {
+      "scopeNoteByLang": {
         "sv": "metodutveckling under 10203",
         "en": "Methods development to be 10203"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/106"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/106"},
       "hiddenLabelByLang": {"sv": "Bioinformatik och systembiologi (metodutveckling under 10203)"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"},
       "narrower": [
         {
           "@type": "Concept",
@@ -995,135 +992,128 @@
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10611",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10611",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10611",
       "prefLabelByLang": {
         "sv": "Ekologi",
         "en": "Ecology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/106"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/106"},
       "narrower": [
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "bevarandebiologi (biodiversitet med lantbruksvetenskaplig inriktning under 40504)",
             "en": "Biodiversity Conservation (Biodiversity within agricultural sciences at 40504)"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "akvatisk ekologi"}
         },
         {
           "@type": "Concept",
-          "prefLabelByLang": {
-            "sv": "",
-            "en": ""
-          }
+          "hiddenLabelByLang": {"sv": "terrester ekologi"}
         },
         {
           "@type": "Concept",
-          "prefLabelByLang": {
-            "sv": "",
-            "en": ""
-          }
+          "hiddenLabelByLang": {"sv": "bevarandebiologi"}
         }
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10612",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10612",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10612",
       "prefLabelByLang": {
         "sv": "Biologisk systematik",
         "en": "Biological Systematics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/106"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/106"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10613",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10613",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10613",
       "prefLabelByLang": {
         "sv": "Etologi",
         "en": "Behavioural Sciences Biology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/106"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/106"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10614",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10614",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10614",
       "prefLabelByLang": {
         "sv": "Utvecklingsbiologi",
         "en": "Developmental Biology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/106"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/106"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10615",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10615",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10615",
       "prefLabelByLang": {
         "sv": "Evolutionsbiologi",
         "en": "Evolutionary Biology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/106"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/106"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10616",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10616",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10616",
       "prefLabelByLang": {
         "sv": "Molekylärbiologi",
         "en": "Molecular Biology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/106"},
-      "scopeNoteByLang": {"sv": "Uppdelning av ämne"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/106"},
       "historyNoteByLang": {"sv": "Biokemi och molekylärbiologi 10602 (SSIF2011) har delats upp i två separata ämnen. Biokemi 10408 (SSIF 2025) ingår nu i Kemi 104 medan Molekylärbiologi 10616 (SSIF2025) fortsatt ingår i Biologi 106."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10699",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10699",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10699",
       "prefLabelByLang": {
         "sv": "Annan biologi",
         "en": "Other Biological Topics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/106"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/106"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/107",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/107",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "107",
       "prefLabelByLang": {
         "sv": "Annan naturvetenskap",
         "en": "Other Natural Sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/1"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/1"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/10799",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/10799",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "10799",
       "prefLabelByLang": {
         "sv": "Annan naturvetenskap",
         "en": "Other Natural Sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/107"},
-      "hiddenLabelByLang": {"sv": "Övrig annan naturvetenskap"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/107"},
+      "hiddenLabelByLang": {"sv": "Övrig annan naturvetenskap"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/2",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/2",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "2",
       "prefLabelByLang": {
         "sv": "Teknik",
@@ -1131,40 +1121,38 @@
       }
     },
     {
-      "@id": "https://id.kb.se/term/ssif/201",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/201",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "201",
       "prefLabelByLang": {
         "sv": "Samhällsbyggnadsteknik",
         "en": "Civil Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/2"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/2"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20101",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20101",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20101",
       "prefLabelByLang": {
         "sv": "Arkitekturteknik",
         "en": "Architectural Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/201"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/201"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20102",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20102",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20102",
       "prefLabelByLang": {
         "sv": "Byggprocess och förvaltning",
         "en": "Construction Management"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/201"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/201"},
       "hiddenLabelByLang": {"sv": "Byggproduktion"},
-      "scopeNoteByLang": {"sv": "Sammanslagning av ämnen"},
-      "historyNoteByLang": {"sv": "Miljöanalys och bygginformatik 20108 (SSIF2011) och Byggproduktion 20102 (SSIF2011) har slagits samman till Byggprocess och förvaltning 20102 (SSIF2025)."},
       "narrower": [
         {
           "@type": "Concept",
@@ -1173,386 +1161,371 @@
             "en": "Environmental Analysis and Construction Information Technology"
           }
         }
-      ]
+      ],
+      "historyNoteByLang": {"sv": "Miljöanalys och bygginformatik 20108 (SSIF2011) och Byggproduktion 20102 (SSIF2011) har slagits samman till Byggprocess och förvaltning 20102 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20103",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20103",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20103",
       "prefLabelByLang": {
         "sv": "Husbyggnad",
         "en": "Building Technologies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/201"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/201"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20104",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20104",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20104",
       "prefLabelByLang": {
         "sv": "Infrastrukturteknik",
         "en": "Infrastructure Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/201"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/201"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20105",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20105",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20105",
       "prefLabelByLang": {
         "sv": "Transportteknik och logistik",
         "en": "Transport Systems and Logistics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/201"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/201"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20106",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20106",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20106",
       "prefLabelByLang": {
         "sv": "Geoteknik och teknisk geologi",
         "en": "Geotechnical Engineering and Engineering Geology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/201"},
-      "hiddenLabelByLang": {"sv": "Geoteknik"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/201"},
+      "hiddenLabelByLang": {"sv": "Geoteknik"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20107",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20107",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20107",
       "prefLabelByLang": {
         "sv": "Vattenteknik",
         "en": "Water Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/201"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/201"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20108",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/20108",
+      "@type": "Concept",
       "code": "20108",
-      "hiddenLabel": "Miljöanalys och bygginformationsteknik",
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Miljöanalys och bygginformationsteknik"},
       "isReplacedBy": [
-        {"@id": "https://id.kb.se/term/ssif/20102"}
-      ]
+        {"@id": "https://begrepp.uka.se/SSIF/20102"}
+      ],
+      "historyNoteByLang": {"sv": "Miljöanalys och bygginformatik 20108 (SSIF2011) och Byggproduktion 20102 (SSIF2011) har slagits samman till Byggprocess och förvaltning 20102 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20109",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20109",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20109",
       "prefLabelByLang": {
         "sv": "Byggkonstruktion",
         "en": "Structural Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/201"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/201"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20110",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20110",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20110",
       "prefLabelByLang": {
         "sv": "Byggnadsmaterial",
         "en": "Building materials"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/201"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/201"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20199",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20199",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20199",
       "prefLabelByLang": {
         "sv": "Annan samhällsbyggnadsteknik",
         "en": "Other Civil Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/201"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/201"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/202",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/202",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "202",
       "prefLabelByLang": {
         "sv": "Elektroteknik och elektronik",
         "en": "Electrical Engineering, Electronic Engineering, Information Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/2"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/2"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20201",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20201",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20201",
       "prefLabelByLang": {
         "sv": "Robotik och automation",
         "en": "Robotics and automation"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/202"},
-      "hiddenLabelByLang": {"sv": "Robotteknik och automation"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/202"},
+      "hiddenLabelByLang": {"sv": "Robotteknik och automation"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20202",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20202",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20202",
       "prefLabelByLang": {
         "sv": "Reglerteknik",
         "en": "Control Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/202"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/202"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20203",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20203",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20203",
       "prefLabelByLang": {
         "sv": "Kommunikationssystem",
         "en": "Communication Systems"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/202"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/202"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20204",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20204",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20204",
       "prefLabelByLang": {
         "sv": "Telekommunikation",
         "en": "Telecommunications"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/202"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/202"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20205",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20205",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20205",
       "prefLabelByLang": {
         "sv": "Signalbehandling",
         "en": "Signal Processing"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/202"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/202"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20206",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20206",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20206",
       "prefLabelByLang": {
         "sv": "Datorsystem",
         "en": "Computer Systems"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/202"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/202"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20207",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20207",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20207",
       "prefLabelByLang": {
         "sv": "Inbäddad systemteknik",
         "en": "Embedded Systems"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/202"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/202"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20208",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20208",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20208",
       "prefLabelByLang": {
         "sv": "Datorseende och lärande system",
         "en": "Computer Vision and learning System"
       },
-      "commentByLang": {
+      "scopeNoteByLang": {
         "sv": "datavetenskapliga aspekter under 10207",
         "en": "Computer Sciences aspects in 10207"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/202"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/202"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20209",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20209",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20209",
       "prefLabelByLang": {
         "sv": "Elkraftsystem och -komponenter",
         "en": "Power Systems and Components"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/202"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/202"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20299",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20299",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20299",
       "prefLabelByLang": {
         "sv": "Annan elektroteknik och elektronik",
         "en": "Other Electrical Engineering, Electronic Engineering, Information Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/202"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/202"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/203",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/203",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "203",
       "prefLabelByLang": {
         "sv": "Maskinteknik",
         "en": "Mechanical Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/2"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/2"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20301",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20301",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20301",
       "prefLabelByLang": {
         "sv": "Teknisk mekanik",
         "en": "Applied Mechanics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/203"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/203"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20302",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20302",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20302",
       "prefLabelByLang": {
         "sv": "Farkost och rymdteknik",
         "en": "Vehicle and Aerospace Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/203"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/203"},
       "hiddenLabelByLang": {"sv": "Rymd- och flygteknik"},
-      "scopeNoteByLang": {"sv": "Sammanslagning av ämnen"},
-      "historyNoteByLang": {"sv": "Farkostteknik 20303 (SSIF2011) och Rymd- och flygteknik 20302 (SSIF 2011) har slagits samman till Farkost och rymdteknik 20302 (SSIF2025)."},
       "narrower": [
         {
           "@type": "Concept",
-          "prefLabelByLang": {
-            "sv": "flygteknik",
-            "en": ""
-          }
+          "prefLabelByLang": {"sv": "flygteknik"}
         },
         {
           "@type": "Concept",
-          "prefLabelByLang": {
-            "sv": "",
-            "en": ""
-          }
+          "hiddenLabelByLang": {"sv": "Farkostteknik"}
         }
-      ]
+      ],
+      "historyNoteByLang": {"sv": "Farkostteknik 20303 (SSIF2011) och Rymd- och flygteknik 20302 (SSIF 2011) har slagits samman till Farkost och rymdteknik 20302 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20303",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/20303",
+      "@type": "Concept",
       "code": "20303",
-      "hiddenLabel": "Farkostteknik",
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Farkostteknik"},
       "isReplacedBy": [
-        {"@id": "https://id.kb.se/term/ssif/20302"}
-      ]
+        {"@id": "https://begrepp.uka.se/SSIF/20302"}
+      ],
+      "historyNoteByLang": {"sv": "Farkostteknik 20303 (SSIF2011) och Rymd- och flygteknik 20302 (SSIF 2011) har slagits samman till Farkost och rymdteknik 20302 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20304",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20304",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20304",
       "prefLabelByLang": {
         "sv": "Energiteknik",
         "en": "Energy Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/203"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/203"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20305",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20305",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20305",
       "prefLabelByLang": {
         "sv": "Tillförlitlighets- och kvalitetsteknik",
         "en": "Reliability and Maintenance"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/203"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/203"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20306",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20306",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20306",
       "prefLabelByLang": {
         "sv": "Strömningsmekanik",
         "en": "Fluid Mechanics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/203"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/203"},
       "hiddenLabelByLang": {"sv": "Strömningsmekanik och akustik"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"},
       "historyNoteByLang": {"sv": "Akustik som tidigare var del av ämnet ingår numera i Annan maskinteknik 20399 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20307",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20307",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20307",
       "prefLabelByLang": {
         "sv": "Produktionsteknik, arbetsvetenskap och ergonomi",
         "en": "Production Engineering, Human Work Science and Ergonomics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/203"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/203"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20308",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/20308",
+      "@type": "Concept",
       "code": "20308",
-      "hiddenLabel": "Tribologi (ytteknik omfattande friktion, nötning och smörjning)",
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Tribologi (ytteknik omfattande friktion, nötning och smörjning)"},
       "isReplacedBy": [
-        {"@id": "https://id.kb.se/term/ssif/20399"}
-      ]
+        {"@id": "https://begrepp.uka.se/SSIF/20399"}
+      ],
+      "historyNoteByLang": {"sv": "Tribologi 20308 (SSIF2011) ingår numera i Annan maskinteknik 20399 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20309",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20309",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20309",
       "prefLabelByLang": {
         "sv": "Solid- och strukturmekanik",
         "en": "Solid and Structural Mechanics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/203"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/203"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20399",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20399",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20399",
       "prefLabelByLang": {
         "sv": "Annan maskinteknik",
         "en": "Other Mechanical Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/203"},
-      "scopeNoteByLang": {"sv": "Annan"},
-      "historyNoteByLang": {"sv": "Tribologi 20308 (SSIF2011) och akustik som var en delmängd av 20306 (SSIF2011) ingår numera i Annan maskinteknik 20399 (SSIF2025). Industriell ekonomi 20310 (SSIF2025) ingick tidigare i Annan maskinteknik 20399 (SSIF2011)."},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/203"},
       "related": [
-        {
-          "@id": "https://id.kb.se/term/ssif/20310",
-          "@annotation": {
-            "commentByLang": {"sv": "Uppdelning av ämne"}
-          }
-        }
+        {"@id": "https://begrepp.uka.se/SSIF/20310"}
       ],
       "narrower": [
         {
@@ -1560,28 +1533,32 @@
           "prefLabelByLang": {
             "sv": "logistik",
             "en": "Logistics"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "logistik"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "förbränningsteknik",
             "en": "Combustion Technology"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "förbränningsteknik"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "återvinningsteknik",
             "en": "Recycling Technology"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "återvinningsteknik"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "tribologi",
             "en": "Tribology"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "industriell ekonomi"}
         },
         {
           "@type": "Concept",
@@ -1590,44 +1567,43 @@
             "en": "Acoustics"
           }
         }
-      ]
+      ],
+      "historyNoteByLang": {"sv": "Tribologi 20308 (SSIF2011) och akustik som var en delmängd av 20306 (SSIF2011) ingår numera i Annan maskinteknik 20399 (SSIF2025). Industriell ekonomi 20310 (SSIF2025) ingick tidigare i Annan maskinteknik 20399 (SSIF2011)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20310",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20310",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20310",
       "prefLabelByLang": {
         "sv": "Industriell ekonomi",
         "en": "Industrial engineering and management"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/203"},
-      "scopeNoteByLang": {"sv": "Uppdelning av ämne"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/203"},
       "historyNoteByLang": {"sv": "Industriell ekonomi 20310 (SSIF2025) ingick tidigare i Annan maskinteknik 20399 (SSIF2011)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/204",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/204",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "204",
       "prefLabelByLang": {
         "sv": "Kemiteknik",
         "en": "Chemical Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/2"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/2"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20402",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20402",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20402",
       "prefLabelByLang": {
         "sv": "Yt- och korrosionsteknik",
         "en": "Surface- and Corrosion Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/204"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/204"},
       "hiddenLabelByLang": {"sv": "Korrosionsteknik"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"},
       "narrower": [
         {
           "@type": "Concept",
@@ -1639,242 +1615,224 @@
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20403",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20403",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20403",
       "prefLabelByLang": {
         "sv": "Polymerteknologi",
         "en": "Polymer Technologies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/204"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/204"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20404",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/20404",
+      "@type": "Concept",
       "code": "20404",
-      "hiddenLabel": "Farmaceutisk synteskemi",
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Farmaceutisk synteskemi"},
       "isReplacedBy": [
-        {"@id": "https://id.kb.se/term/ssif/20499"}
-      ]
+        {"@id": "https://begrepp.uka.se/SSIF/20499"}
+      ],
+      "historyNoteByLang": {"sv": "Farmaceutisk synteskemi 20404 (SSIF2011) kan exempelvis redovisas i Annan kemiteknik 20499 (SSIF2025)"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20401",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/20401",
+      "@type": "Concept",
       "code": "20401",
-      "hiddenLabelByLang": {"sv": "Kemiska processer"},
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Kemiska processer"},
       "isReplacedBy": [
-        {
-          "@id": "https://id.kb.se/term/ssif/20405",
-          "@annotation": {
-            "commentByLang": {"sv": "Uppdelning av ämne"}
-          }
-        },
-        {
-          "@id": "https://id.kb.se/term/ssif/20406",
-          "@annotation": {
-            "commentByLang": {"sv": "Uppdelning av ämne"}
-          }
-        }
+        {"@id": "https://begrepp.uka.se/SSIF/20405"},
+        {"@id": "https://begrepp.uka.se/SSIF/20406"}
+      ],
+      "narrowMatch": [
+        {"@id": "https://begrepp.uka.se/SSIF/20405"},
+        {"@id": "https://begrepp.uka.se/SSIF/20406"}
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20405",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20405",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20405",
       "prefLabelByLang": {
         "sv": "Katalytiska processer",
         "en": "Catalytic Processes"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/204"},
-      "scopeNoteByLang": {"sv": "Uppdelning av ämne"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/204"},
       "historyNoteByLang": {"sv": "Kemiska processer 20401 (SSIF2011) har delats upp i Katalytiska processer 20405 (SSIF2025) och Separationsprocesser 20406 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20406",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20406",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20406",
       "prefLabelByLang": {
         "sv": "Separationsprocesser",
         "en": "Separation Processes"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/204"},
-      "scopeNoteByLang": {"sv": "Uppdelning av ämne"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/204"},
       "historyNoteByLang": {"sv": "Kemiska processer 20401 (SSIF2011) har delats upp i Katalytiska processer 20405 (SSIF2025) och Separationsprocesser 20406 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/21101",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/21101",
+      "@type": "Concept",
       "code": "21101",
-      "hiddenLabelByLang": {"sv": "Livsmedelsteknik"},
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Livsmedelsteknik"},
       "isReplacedBy": [
-        {
-          "@id": "https://id.kb.se/term/ssif/20407",
-          "@annotation": {
-            "commentByLang": {"sv": "Bytt forskningsämnesgrupp, Uppdelning av ämne"}
-          }
-        },
-        {
-          "@id": "https://id.kb.se/term/ssif/20909",
-          "@annotation": {
-            "commentByLang": {"sv": "Bytt forskningsämnesgrupp, Uppdelning av ämne"}
-          }
-        }
+        {"@id": "https://begrepp.uka.se/SSIF/20407"},
+        {"@id": "https://begrepp.uka.se/SSIF/20909"}
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20407",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20407",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20407",
       "prefLabelByLang": {
         "sv": "Livsmedelsprocessteknik",
         "en": "Circular Food Process Technologies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/204"},
-      "scopeNoteByLang": {"sv": "Bytt forskningsämnesgrupp, Uppdelning av ämne"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/204"},
       "historyNoteByLang": {"sv": "Livsmedelsteknik 21101 (SSIF2011) har nu delats upp i Livsmedelsbioteknik 20909 (SSIF2025) och Livsmedelsprocessteknik 20407 (SSIF2025)"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20499",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20499",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20499",
       "prefLabelByLang": {
         "sv": "Annan kemiteknik",
         "en": "Other Chemical Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/204"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/204"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/205",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/205",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "205",
       "prefLabelByLang": {
         "sv": "Materialteknik",
         "en": "Materials Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/2"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/2"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20501",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20501",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20501",
       "prefLabelByLang": {
         "sv": "Keramiska och pulvermetallurgiska material",
         "en": "Ceramics and Powder Metallurgical Materials"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/205"},
-      "hiddenLabelByLang": {"sv": "Keramteknik"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/205"},
+      "hiddenLabelByLang": {"sv": "Keramteknik"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20502",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20502",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20502",
       "prefLabelByLang": {
         "sv": "Kompositmaterial och kompositteknik",
         "en": "Composite Science and Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/205"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/205"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20503",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20503",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20503",
       "prefLabelByLang": {
         "sv": "Pappers-, massa-  och fiberteknik",
         "en": "Paper, Pulp and Fiber Technology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/205"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/205"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20504",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20504",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20504",
       "prefLabelByLang": {
         "sv": "Textil-, gummi- och polymermaterial",
         "en": "Textile, Rubber and Polymeric Materials"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/205"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/205"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20505",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20505",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20505",
       "prefLabelByLang": {
         "sv": "Bearbetnings-, yt- och fogningsteknik",
         "en": "Manufacturing, Surface and Joining Technology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/205"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/205"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20506",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20506",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20506",
       "prefLabelByLang": {
         "sv": "Metallurgi och metalliska material",
         "en": "Metallurgy and Metallic Materials"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/205"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/205"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20599",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20599",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20599",
       "prefLabelByLang": {
         "sv": "Annan materialteknik",
         "en": "Other Materials Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/205"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/205"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/206",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/206",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "206",
       "prefLabelByLang": {
         "sv": "Medicinteknik",
         "en": "Medical Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/2"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/2"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20601",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20601",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20601",
       "prefLabelByLang": {
         "sv": "Medicinsk laboratorieteknik",
         "en": "Medical Laboratory Technologies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/206"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/206"},
       "hiddenLabelByLang": {"sv": "Medicinsk laboratorie- och mätteknik"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"},
       "historyNoteByLang": {"sv": "Mätteknik som tidigare var del av ämnet ingår numera i Medicinsk instrumentering 20604 (SSIF2025)"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20602",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20602",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20602",
       "prefLabelByLang": {
         "sv": "Medicinsk materialteknik",
         "en": "Medical Materials"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/206"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/206"},
       "hiddenLabelByLang": {"sv": "Medicinsk material- och protesteknik"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"},
       "narrower": [
         {
           "@type": "Concept",
@@ -1886,31 +1844,28 @@
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20603",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20603",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20603",
       "prefLabelByLang": {
         "sv": "Medicinsk bildvetenskap",
         "en": "Medical Imaging"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/206"},
-      "hiddenLabelByLang": {"sv": "Medicinsk bildbehandling"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/206"},
+      "hiddenLabelByLang": {"sv": "Medicinsk bildbehandling"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20604",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20604",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20604",
       "prefLabelByLang": {
         "sv": "Medicinsk instrumentering",
         "en": "Medical Instrumentation"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/206"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/206"},
       "hiddenLabelByLang": {"sv": "Medicinsk apparatteknik"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"},
-      "historyNoteByLang": {"sv": "Mätteknik som tidigare var del av 20601 (SSIF2011) ingår numera i Medicinsk instrumentering 20604 (SSIF2025)"},
       "narrower": [
         {
           "@type": "Concept",
@@ -1919,92 +1874,91 @@
             "en": "Measurement Technologies"
           }
         }
-      ]
+      ],
+      "historyNoteByLang": {"sv": "Mätteknik som tidigare var del av 20601 (SSIF2011) ingår numera i Medicinsk instrumentering 20604 (SSIF2025)"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20605",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20605",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20605",
       "prefLabelByLang": {
         "sv": "Medicinsk modellering och simulering",
         "en": "Medical Modelling and Simulation"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/206"},
-      "hiddenLabelByLang": {"sv": "Medicinsk ergonomi"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/206"},
+      "hiddenLabelByLang": {"sv": "Medicinsk ergonomi"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20606",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20606",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20606",
       "prefLabelByLang": {
         "sv": "Medicinteknisk informatik",
         "en": "Medical Informatics Engineering"
       },
-      "commentByLang": {
+      "scopeNoteByLang": {
         "sv": "medicinska aspekter under 30117",
         "en": "Medical aspects at 30117"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/206"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/206"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20699",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20699",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20699",
       "prefLabelByLang": {
         "sv": "Annan medicinteknik",
         "en": "Other Medical Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/206"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/206"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/207",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/207",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "207",
       "prefLabelByLang": {
         "sv": "Naturresursteknik",
         "en": "Environmental Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/2"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/2"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20701",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/20701",
+      "@type": "Concept",
       "code": "20701",
-      "hiddenLabel": "Geofysisk teknik",
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Geofysisk teknik"},
       "isReplacedBy": [
-        {"@id": "https://id.kb.se/term/ssif/20703"}
-      ]
+        {"@id": "https://begrepp.uka.se/SSIF/20703"}
+      ],
+      "historyNoteByLang": {"sv": "Geofysisk teknik 20701 (SSIF2011) och Fjärranalysteknik 20703 (SSIF2011) har slagits samman till Jordobservationsteknik 20703 (SSIF2025)"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20702",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20702",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20702",
       "prefLabelByLang": {
         "sv": "Energisystem",
         "en": "Energy Systems"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/207"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/207"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20703",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20703",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20703",
       "prefLabelByLang": {
         "sv": "Jordobservationsteknik",
         "en": "Earth Observation"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/207"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/207"},
       "hiddenLabelByLang": {"sv": "Fjärranalysteknik"},
-      "scopeNoteByLang": {"sv": "Sammanslagning av ämnen"},
-      "historyNoteByLang": {"sv": "Geofysisk teknik 20701 (SSIF2011) och Fjärranalysteknik 20703 (SSIF2011) har slagits samman till Jordobservationsteknik 20703 (SSIF2025)."},
       "narrower": [
         {
           "@type": "Concept",
@@ -2034,32 +1988,31 @@
             "en": "Geographical information technology"
           }
         }
-      ]
+      ],
+      "historyNoteByLang": {"sv": "Geofysisk teknik 20701 (SSIF2011) och Fjärranalysteknik 20703 (SSIF2011) har slagits samman till Jordobservationsteknik 20703 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20704",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20704",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20704",
       "prefLabelByLang": {
         "sv": "Mineral- och gruvteknik",
         "en": "Mineral and Mine Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/207"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/207"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20705",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20705",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20705",
       "prefLabelByLang": {
         "sv": "Marinteknik",
         "en": "Marine Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/207"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/207"},
       "hiddenLabelByLang": {"sv": "Marin teknik"},
-      "scopeNoteByLang": {"sv": "Sammanslagning av ämnen"},
-      "historyNoteByLang": {"sv": "Havs- och vattendragsteknik 20706 (SSIF2011) ingår numera i Marinteknik 20705 (SSIF2025)."},
       "narrower": [
         {
           "@type": "Concept",
@@ -2070,135 +2023,133 @@
         },
         {
           "@type": "Concept",
-          "prefLabelByLang": {
-            "sv": "",
-            "en": ""
-          }
+          "hiddenLabelByLang": {"sv": "Havs- och vattendragsteknik"}
         }
-      ]
+      ],
+      "historyNoteByLang": {"sv": "Havs- och vattendragsteknik 20706 (SSIF2011) ingår numera i Marinteknik 20705 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20706",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/20706",
+      "@type": "Concept",
       "code": "20706",
-      "hiddenLabel": "Havs- och vattendragsteknik",
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Havs- och vattendragsteknik"},
       "isReplacedBy": [
-        {"@id": "https://id.kb.se/term/ssif/20705"}
-      ]
+        {"@id": "https://begrepp.uka.se/SSIF/20705"}
+      ],
+      "historyNoteByLang": {"sv": "Havs- och vattendragsteknik 20706 (SSIF2011) ingår numera i Marinteknik 20705 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20707",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20707",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20707",
       "prefLabelByLang": {
         "sv": "Miljöteknik och miljöledning",
         "en": "Environmental Management"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/207"},
-      "hiddenLabelByLang": {"sv": "Miljöledning"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/207"},
+      "hiddenLabelByLang": {"sv": "Miljöledning"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20799",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20799",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20799",
       "prefLabelByLang": {
         "sv": "Annan naturresursteknik",
         "en": "Other Environmental Engineering"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/207"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/207"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/208",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/208",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "208",
       "prefLabelByLang": {
         "sv": "Miljöbioteknik",
         "en": "Environmental Biotechnology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/2"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/2"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20801",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20801",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20801",
       "prefLabelByLang": {
         "sv": "Biosanering",
         "en": "Bioremediation"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/208"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/208"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20802",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20802",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20802",
       "prefLabelByLang": {
         "sv": "Diagnostisk bioteknologi",
         "en": "Diagnostic Biotechnology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/208"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/208"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20803",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20803",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20803",
       "prefLabelByLang": {
         "sv": "Vattenbehandlingsbioteknik",
         "en": "Water Treatment"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/208"},
-      "hiddenLabelByLang": {"sv": "Vattenbehandling"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/208"},
+      "hiddenLabelByLang": {"sv": "Vattenbehandling"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20804",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/20804",
+      "@type": "Concept",
       "code": "20804",
-      "hiddenLabel": "Bioteknisk etik",
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Bioteknisk etik"},
       "isReplacedBy": [
-        {"@id": "https://id.kb.se/term/ssif/20899"}
-      ]
+        {"@id": "https://begrepp.uka.se/SSIF/20899"}
+      ],
+      "historyNoteByLang": {"sv": "Bioteknisk etik 20804 (SSIF2011) ingår numera i Annan miljöbioteknik 20899."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20899",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20899",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20899",
       "prefLabelByLang": {
         "sv": "Annan miljöbioteknik",
         "en": "Other Environmental Biotechnology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/208"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/208"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/209",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/209",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "209",
       "prefLabelByLang": {
         "sv": "Industriell bioteknik",
         "en": "Industrial Biotechnology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/2"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/2"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20901",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20901",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20901",
       "prefLabelByLang": {
         "sv": "Bioprocessteknik",
         "en": "Bioprocess Technology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/209"},
-      "scopeNoteByLang": {"sv": "Sammanslagning av ämnen"},
-      "historyNoteByLang": {"sv": "Bioteknisk apparatteknik 20907 (SSIF2011) ingår numera i Bioprocessteknik 20901 (SSIF2025)."},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/209"},
       "narrower": [
         {
           "@type": "Concept",
@@ -2207,239 +2158,246 @@
             "en": "Bioengineering Equipment"
           }
         }
-      ]
+      ],
+      "historyNoteByLang": {"sv": "Bioteknisk apparatteknik 20907 (SSIF2011) ingår numera i Bioprocessteknik 20901 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20902",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20902",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20902",
       "prefLabelByLang": {
         "sv": "Biokemikalier",
         "en": "Biochemicals"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/209"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/209"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20903",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20903",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20903",
       "prefLabelByLang": {
         "sv": "Biomaterial",
         "en": "Bio Materials"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/209"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/209"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20904",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20904",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20904",
       "prefLabelByLang": {
         "sv": "Bioenergi",
         "en": "Bioenergy"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/209"},
-      "scopeNoteByLang": {"sv": "Annan"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/209"},
       "historyNoteByLang": {"sv": "Förnyelsebar bioenergi 40501 (SSIF2011) ingår nu i 20904 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20905",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20905",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20905",
       "prefLabelByLang": {
         "sv": "Läkemedel- och medicinsk processbioteknik",
         "en": "Pharmaceutical and Medical Biotechnology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/209"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/209"},
       "hiddenLabelByLang": {"sv": "Läkemedelsbioteknik"},
-      "scopeNoteByLang": {"sv": "Sammanslagning av ämnen"},
       "historyNoteByLang": {"sv": "Läkemedelsbioteknik 20905 (SSIF2011) och Medicinsk bioteknik 20908 (SSIF2011) har slagits samman till Läkemedel- och medicinsk processbioteknik 20905 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20906",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20906",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20906",
       "prefLabelByLang": {
         "sv": "Biokatalys och enzymteknik",
         "en": "Biocatalysis and Enzyme Technology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/209"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/209"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20907",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/20907",
+      "@type": "Concept",
       "code": "20907",
-      "hiddenLabel": "Bioteknisk apparatteknik",
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Bioteknisk apparatteknik"},
       "isReplacedBy": [
-        {"@id": "https://id.kb.se/term/ssif/20901"}
-      ]
+        {"@id": "https://begrepp.uka.se/SSIF/20901"}
+      ],
+      "historyNoteByLang": {"sv": "Bioteknisk apparatteknik 20907 (SSIF2011) ingår numera i Bioprocessteknik 20901 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20908",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/20908",
+      "@type": "Concept",
       "code": "20908",
-      "hiddenLabel": "Medicinsk bioteknik",
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Medicinsk bioteknik"},
       "isReplacedBy": [
-        {"@id": "https://id.kb.se/term/ssif/20905"}
-      ]
+        {"@id": "https://begrepp.uka.se/SSIF/20905"}
+      ],
+      "historyNoteByLang": {"sv": "Läkemedelsbioteknik 20905 (SSIF2011) och Medicinsk bioteknik 20908 (SSIF2011) har slagits samman till Läkemedel- och medicinsk processbioteknik 20905 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20909",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20909",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20909",
       "prefLabelByLang": {
         "sv": "Livsmedelsbioteknik",
         "en": "Food Biotechnology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/209"},
-      "scopeNoteByLang": {"sv": "Bytt forskningsämnesgrupp, Uppdelning av ämne"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/209"},
       "historyNoteByLang": {"sv": "Livsmedelsteknik 21101 (SSIF2011) har nu delats upp i Livsmedelsbioteknik 20909 (SSIF2025) och Livsmedelsprocessteknik 20407 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/20999",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/20999",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "20999",
       "prefLabelByLang": {
         "sv": "Annan industriell bioteknik",
         "en": "Other Industrial Biotechnology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/209"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/209"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/210",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/210",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "210",
       "prefLabelByLang": {
         "sv": "Nanoteknik",
         "en": "Nano-technology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/2"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/2"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/21001",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/21001",
+      "@type": "Concept",
       "code": "21001",
-      "hiddenLabel": "Nanoteknik",
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Nanoteknik"},
       "isReplacedBy": [
-        {"@id": "https://id.kb.se/term/ssif/21002"},
-        {"@id": "https://id.kb.se/term/ssif/21003"},
-        {"@id": "https://id.kb.se/term/ssif/21004"},
-        {"@id": "https://id.kb.se/term/ssif/21005"}
-      ]
+        {"@id": "https://begrepp.uka.se/SSIF/21002"},
+        {"@id": "https://begrepp.uka.se/SSIF/21003"},
+        {"@id": "https://begrepp.uka.se/SSIF/21004"},
+        {"@id": "https://begrepp.uka.se/SSIF/21005"}
+      ],
+      "narrowMatch": [
+        {"@id": "https://begrepp.uka.se/SSIF/21002"},
+        {"@id": "https://begrepp.uka.se/SSIF/21003"},
+        {"@id": "https://begrepp.uka.se/SSIF/21004"}
+      ],
+      "historyNoteByLang": {"sv": "Ämnet har delats upp i flera ämnen under Nanoteknik 210."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/21002",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/21002",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "21002",
       "prefLabelByLang": {
         "sv": "Nanoteknisk elektronik",
         "en": "Nanotechnology for Electronic Applications"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/210"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/210"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/21003",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/21003",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "21003",
       "prefLabelByLang": {
         "sv": "Nanoteknisk materialvetenskap",
         "en": "Nanotechnology for Material Science"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/210"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/210"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/21004",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/21004",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "21004",
       "prefLabelByLang": {
         "sv": "Nanotekniska energitillämpningar",
         "en": "Nanotechnology for Energy Applications"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/210"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/210"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/21005",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/21005",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "21005",
       "prefLabelByLang": {
         "sv": "Nanotekniska livsvetenskaper och medicin",
         "en": "Nanotechnology for/in Life Science and Medicine"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/210"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/210"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/21099",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/21099",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "21099",
       "prefLabelByLang": {
         "sv": "Annan nanoteknik",
         "en": "Other Nanotechnology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/210"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/210"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/211",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/211",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "211",
       "prefLabelByLang": {
         "sv": "Annan teknik",
         "en": "Other Engineering and Technologies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/2"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/2"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/21102",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/21102",
+      "@type": "Concept",
       "code": "21102",
-      "hiddenLabel": "Mediateknik",
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Mediateknik"},
       "isReplacedBy": [
-        {"@id": "https://id.kb.se/term/ssif/21199"}
-      ]
+        {"@id": "https://begrepp.uka.se/SSIF/21199"}
+      ],
+      "historyNoteByLang": {"sv": "Kan exempelvis ingå i Annan teknik 21199 (SSIF2025) eller det ämne som ligger närmst utbildningen/forskningen."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/21103",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/21103",
+      "@type": "Concept",
       "code": "21103",
-      "hiddenLabel": "Interaktionsteknik",
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Interaktionsteknik"},
       "isReplacedBy": [
-        {"@id": "https://id.kb.se/term/ssif/21199"}
-      ]
+        {"@id": "https://begrepp.uka.se/SSIF/21199"}
+      ],
+      "historyNoteByLang": {"sv": "Kan exempelvis ingå i Annan teknik 21199 (SSIF2025) eller det ämne som ligger närmst utbildningen/forskningen."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/21199",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/21199",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "21199",
       "prefLabelByLang": {
         "sv": "Annan teknik",
         "en": "Other Engineering and Technologies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/211"},
-      "hiddenLabelByLang": {"sv": "Övrig annan teknik"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/211"},
+      "hiddenLabelByLang": {"sv": "Övrig annan teknik"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/3",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/3",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "3",
       "prefLabelByLang": {
         "sv": "Medicin och hälsovetenskap",
@@ -2447,100 +2405,98 @@
       }
     },
     {
-      "@id": "https://id.kb.se/term/ssif/301",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/301",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "301",
       "prefLabelByLang": {
         "sv": "Medicinska och farmaceutiska grundvetenskaper",
         "en": "Basic Medicine"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/3"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/3"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30101",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30101",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30101",
       "prefLabelByLang": {
         "sv": "Farmaceutiska vetenskaper",
         "en": "Pharmaceutical Sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/301"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/301"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30102",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30102",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30102",
       "prefLabelByLang": {
         "sv": "Farmakologi och toxikologi",
         "en": "Pharmacology and Toxicology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/301"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/301"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30103",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30103",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30103",
       "prefLabelByLang": {
         "sv": "Läkemedelskemi",
         "en": "Medicinal Chemistry"
       },
-      "commentByLang": {
+      "scopeNoteByLang": {
         "sv": "naturvetenskaplig inriktning under 10405",
         "en": "Natural Sciences at 10405"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/301"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/301"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30104",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30104",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30104",
       "prefLabelByLang": {
         "sv": "Samhällsfarmaci och klinisk farmaci",
         "en": "Social and Clinical Pharmacy"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/301"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/301"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30105",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30105",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30105",
       "prefLabelByLang": {
         "sv": "Neurovetenskaper",
         "en": "Neurosciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/301"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/301"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30106",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30106",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30106",
       "prefLabelByLang": {
         "sv": "Fysiologi och anatomi",
         "en": "Physiology and Anatomy"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/301"},
-      "hiddenLabelByLang": {"sv": "Fysiologi"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/301"},
+      "hiddenLabelByLang": {"sv": "Fysiologi"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30107",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30107",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30107",
       "prefLabelByLang": {
         "sv": "Medicinsk genetik och genomik",
         "en": "Medical Genetics and Genomics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/301"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/301"},
       "hiddenLabelByLang": {"sv": "Medicinsk genetik"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"},
       "narrower": [
         {
           "@type": "Concept",
@@ -2552,37 +2508,37 @@
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30108",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30108",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30108",
       "prefLabelByLang": {
         "sv": "Cell- och molekylärbiologi",
         "en": "Cell and Molecular Biology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/301"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/301"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30109",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30109",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30109",
       "prefLabelByLang": {
         "sv": "Mikrobiologi inom det medicinska området",
         "en": "Microbiology in the Medical Area"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/301"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/301"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30110",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30110",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30110",
       "prefLabelByLang": {
         "sv": "Immunologi inom det medicinska området",
         "en": "Immunology in the Medical Area"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/301"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/301"},
       "narrower": [
         {
           "@type": "Concept",
@@ -2594,16 +2550,15 @@
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30111",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30111",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30111",
       "prefLabelByLang": {
         "sv": "Medicinska biovetenskaper",
         "en": "Medical Life Sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/301"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/301"},
       "narrower": [
         {
           "@type": "Concept",
@@ -2615,168 +2570,155 @@
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30112",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30112",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30112",
       "prefLabelByLang": {
         "sv": "Basal cancerforskning",
         "en": "Basic Cancer Research"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/301"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/301"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30113",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30113",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30113",
       "prefLabelByLang": {
         "sv": "Medicinsk bioinformatik och systembiologi",
         "en": "Medical Bioinformatics and Systems Biology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/301"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/301"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30114",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30114",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30114",
       "prefLabelByLang": {
         "sv": "Evolution och utvecklingsgenetik",
         "en": "Evolution and Developmental Genetics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/301"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/301"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30115",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30115",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30115",
       "prefLabelByLang": {
         "sv": "Medicinsk epigenetik och epigenomik",
         "en": "Medical Epigenetics and Epigenomics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/301"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/301"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30302",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/30302",
+      "@type": "Concept",
       "code": "30302",
-      "hiddenLabelByLang": {"sv": "Folkhälsovetenskap, global hälsa, socialmedicin och epidemiologi"},
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Folkhälsovetenskap, global hälsa, socialmedicin och epidemiologi"},
       "isReplacedBy": [
-        {
-          "@id": "https://id.kb.se/term/ssif/30116",
-          "@annotation": {
-            "commentByLang": {"sv": "Bytt forskningsämnesgrupp, Uppdelning av ämne"}
-          }
-        },
-        {
-          "@id": "https://id.kb.se/term/ssif/30311",
-          "@annotation": {
-            "commentByLang": {"sv": "Uppdelning av ämne"}
-          }
-        }
+        {"@id": "https://begrepp.uka.se/SSIF/30116"},
+        {"@id": "https://begrepp.uka.se/SSIF/30311"}
+      ],
+      "closeMatch": [
+        {"@id": "https://begrepp.uka.se/SSIF/30311"}
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30116",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30116",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30116",
       "prefLabelByLang": {
         "sv": "Epidemiologi",
         "en": "Epidemiology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/301"},
-      "scopeNoteByLang": {"sv": "Bytt forskningsämnesgrupp, Uppdelning av ämne"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/301"},
       "historyNoteByLang": {"sv": "Epidemiologi 30116 (SSIF2025) var tidigare en del av Folkhälsovetenskap, global hälsa, socialmedicin och epidemiologi 30302 (SSIF2011) men utgör numera ett eget ämne."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30117",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30117",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30117",
       "prefLabelByLang": {
         "sv": "Medicinsk informatik",
         "en": "Medical Informatics"
       },
-      "commentByLang": {
+      "scopeNoteByLang": {
         "sv": "tekniska aspekter under 20606",
         "en": "Technical aspects at 20606"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/301"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/301"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30118",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30118",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30118",
       "prefLabelByLang": {
         "sv": "Medicinsk biostatistik",
         "en": "Medical Biostatistics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/301"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/301"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30199",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30199",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30199",
       "prefLabelByLang": {
         "sv": "Andra medicinska och farmaceutiska grundvetenskaper",
         "en": "Other Basic Medicine"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/301"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/301"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/302",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/302",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "302",
       "prefLabelByLang": {
         "sv": "Klinisk medicin",
         "en": "Clinical Medicine"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/3"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/3"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30201",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30201",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30201",
       "prefLabelByLang": {
         "sv": "Anestesi och intensivvård",
         "en": "Anesthesiology and Intensive Care"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30202",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30202",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30202",
       "prefLabelByLang": {
         "sv": "Hematologi",
         "en": "Hematology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30203",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30203",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30203",
       "prefLabelByLang": {
         "sv": "Cancer och onkologi",
         "en": "Cancer and Oncology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"},
       "narrower": [
         {
           "@type": "Concept",
@@ -2788,94 +2730,93 @@
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30204",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30204",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30204",
       "prefLabelByLang": {
         "sv": "Dermatologi och venereologi",
         "en": "Dermatology and Venereal Diseases"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30205",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30205",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30205",
       "prefLabelByLang": {
         "sv": "Endokrinologi och diabetes",
         "en": "Endocrinology and Diabetes"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30206",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30206",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30206",
       "prefLabelByLang": {
         "sv": "Kardiologi och kardiovaskulära sjukdomar",
         "en": "Cardiology and Cardiovascular Disease"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"},
-      "hiddenLabelByLang": {"sv": "Kardiologi"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"},
+      "hiddenLabelByLang": {"sv": "Kardiologi"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30207",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30207",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30207",
       "prefLabelByLang": {
         "sv": "Neurologi",
         "en": "Neurology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30208",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30208",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30208",
       "prefLabelByLang": {
         "sv": "Radiologi och bildbehandling",
         "en": "Radiology and Medical Imaging"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30209",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30209",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30209",
       "prefLabelByLang": {
         "sv": "Infektionsmedicin",
         "en": "Infectious Medicine"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30211",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30211",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30211",
       "prefLabelByLang": {
         "sv": "Ortopedi",
         "en": "Orthopaedics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30212",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30212",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30212",
       "prefLabelByLang": {
         "sv": "Kirurgi",
         "en": "Surgery"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"},
       "narrower": [
         {
           "@type": "Concept",
@@ -2887,546 +2828,520 @@
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30213",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30213",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30213",
       "prefLabelByLang": {
         "sv": "Gastroenterologi och hepatologi",
         "en": "Gastroenterology and Hepatology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"},
-      "hiddenLabelByLang": {"sv": "Gastroenterologi"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"},
+      "hiddenLabelByLang": {"sv": "Gastroenterologi"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30215",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30215",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30215",
       "prefLabelByLang": {
         "sv": "Psykiatri",
         "en": "Psychiatry"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30216",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30216",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30216",
       "prefLabelByLang": {
         "sv": "Odontologi",
         "en": "Odontology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30217",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30217",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30217",
       "prefLabelByLang": {
         "sv": "Oftalmologi",
         "en": "Ophthalmology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30218",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30218",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30218",
       "prefLabelByLang": {
         "sv": "Oto-rhino-laryngologi",
         "en": "Oto-rhino-laryngology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30219",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30219",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30219",
       "prefLabelByLang": {
         "sv": "Lungmedicin och allergi",
         "en": "Respiratory Medicine and Allergy"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30220",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30220",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30220",
       "prefLabelByLang": {
         "sv": "Gynekologi, obstetrik och reproduktionsmedicin",
         "en": "Gynaecology, Obstetrics and Reproductive Medicine"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"},
-      "hiddenLabelByLang": {"sv": "Reproduktionsmedicin och gynekologi"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"},
+      "hiddenLabelByLang": {"sv": "Reproduktionsmedicin och gynekologi"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30221",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30221",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30221",
       "prefLabelByLang": {
         "sv": "Pediatrik",
         "en": "Pediatrics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30222",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30222",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30222",
       "prefLabelByLang": {
         "sv": "Geriatrik",
         "en": "Geriatrics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30223",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30223",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30223",
       "prefLabelByLang": {
         "sv": "Klinisk laboratoriemedicin",
         "en": "Clinical Laboratory Medicine"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30224",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30224",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30224",
       "prefLabelByLang": {
         "sv": "Allmänmedicin",
         "en": "General Medicine"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30210",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/30210",
+      "@type": "Concept",
       "code": "30210",
-      "hiddenLabelByLang": {"sv": "Reumatologi och inflammation"},
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Reumatologi och inflammation"},
       "isReplacedBy": [
-        {
-          "@id": "https://id.kb.se/term/ssif/30225",
-          "@annotation": {
-            "commentByLang": {"sv": "Uppdelning av ämne"}
-          }
-        },
-        {
-          "@id": "https://id.kb.se/term/ssif/30226",
-          "@annotation": {
-            "commentByLang": {"sv": "Uppdelning av ämne"}
-          }
-        }
+        {"@id": "https://begrepp.uka.se/SSIF/30225"},
+        {"@id": "https://begrepp.uka.se/SSIF/30226"}
+      ],
+      "narrowMatch": [
+        {"@id": "https://begrepp.uka.se/SSIF/30225"},
+        {"@id": "https://begrepp.uka.se/SSIF/30226"}
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30225",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30225",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30225",
       "prefLabelByLang": {
         "sv": "Reumatologi",
         "en": "Rheumatology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"},
-      "scopeNoteByLang": {"sv": "Uppdelning av ämne"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"},
       "historyNoteByLang": {"sv": "Reumatologi 30225 (SSIF2025) var tidigare en del av Reumatologi och inflamation 30210 (SSIF2011) men utgör numera ett eget ämne."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30226",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30226",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30226",
       "prefLabelByLang": {
         "sv": "Autoimmunitet och inflammation",
         "en": "Autoimmunity and Inflammation"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"},
-      "scopeNoteByLang": {"sv": "Uppdelning av ämne"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"},
       "historyNoteByLang": {"sv": "Autoimmunitet och inflamation 30226 (SSIF2025) var tidigare en del av Reumatologi och inflamation 30210 (SSIF2011) men utgör numera ett eget ämne."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30227",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30227",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30227",
       "prefLabelByLang": {
         "sv": "Internmedicin",
         "en": "Internal Medicine"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30214",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/30214",
+      "@type": "Concept",
       "code": "30214",
-      "hiddenLabelByLang": {"sv": "Urologi och njurmedicin"},
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Urologi och njurmedicin"},
       "isReplacedBy": [
-        {
-          "@id": "https://id.kb.se/term/ssif/30228",
-          "@annotation": {
-            "commentByLang": {"sv": "Uppdelning av ämne"}
-          }
-        },
-        {
-          "@id": "https://id.kb.se/term/ssif/30229",
-          "@annotation": {
-            "commentByLang": {"sv": "Uppdelning av ämne"}
-          }
-        }
+        {"@id": "https://begrepp.uka.se/SSIF/30228"},
+        {"@id": "https://begrepp.uka.se/SSIF/30229"}
+      ],
+      "narrowMatch": [
+        {"@id": "https://begrepp.uka.se/SSIF/30228"},
+        {"@id": "https://begrepp.uka.se/SSIF/30229"}
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30228",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30228",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30228",
       "prefLabelByLang": {
         "sv": "Urologi",
         "en": "Urology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"},
-      "scopeNoteByLang": {"sv": "Uppdelning av ämne"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"},
       "historyNoteByLang": {"sv": "Urologi 30228 (SSIF2025) var tidigare en del av Urologi och njurmedicin 30214 (SSIF2011) men utgör numera ett eget ämne."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30229",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30229",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30229",
       "prefLabelByLang": {
         "sv": "Njurmedicin",
         "en": "Nephrology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"},
-      "scopeNoteByLang": {"sv": "Uppdelning av ämne"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"},
       "historyNoteByLang": {"sv": "Njurmedicin 30229 (SSIF2025) var tidigare en del av Urologi och njurmedicin 30214 (SSIF2011) men utgör numera ett eget ämne."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30230",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30230",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30230",
       "prefLabelByLang": {
         "sv": "Förlossnings- och mödravård",
         "en": "Childbirth and Maternity care"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30299",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30299",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30299",
       "prefLabelByLang": {
         "sv": "Annan klinisk medicin",
         "en": "Other Clinical Medicine"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/302"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/302"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/303",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/303",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "303",
       "prefLabelByLang": {
         "sv": "Hälsovetenskap",
         "en": "Health Sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/3"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/3"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30301",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30301",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30301",
       "prefLabelByLang": {
         "sv": "Hälso- och sjukvårdsorganisation, hälsopolitik och hälsoekonomi",
         "en": "Health Care Service and Management, Health Policy and Services and Health Economy"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/303"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/303"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30303",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30303",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30303",
       "prefLabelByLang": {
         "sv": "Arbetsmedicin och miljömedicin",
         "en": "Occupational Health and Environmental Health"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/303"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/303"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30304",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30304",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30304",
       "prefLabelByLang": {
         "sv": "Näringslära och dietkunskap",
         "en": "Nutrition and Dietetics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/303"},
-      "hiddenLabelByLang": {"sv": "Näringslära"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/303"},
+      "hiddenLabelByLang": {"sv": "Näringslära"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30305",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30305",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30305",
       "prefLabelByLang": {
         "sv": "Omvårdnad",
         "en": "Nursing"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/303"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/303"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30306",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30306",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30306",
       "prefLabelByLang": {
         "sv": "Arbetsterapi",
         "en": "Occupational Therapy"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/303"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/303"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30307",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30307",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30307",
       "prefLabelByLang": {
         "sv": "Fysioterapi",
         "en": "Physiotherapy"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/303"},
-      "hiddenLabelByLang": {"sv": "Sjukgymnastik"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/303"},
+      "hiddenLabelByLang": {"sv": "Sjukgymnastik"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30308",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30308",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30308",
       "prefLabelByLang": {
         "sv": "Idrottsvetenskap och fitness",
         "en": "Sport and Fitness Sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/303"},
-      "hiddenLabelByLang": {"sv": "Idrottsvetenskap"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/303"},
+      "hiddenLabelByLang": {"sv": "Idrottsvetenskap"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30309",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30309",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30309",
       "prefLabelByLang": {
         "sv": "Beroendelära och missbruk",
         "en": "Drug Abuse and Addiction"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/303"},
-      "hiddenLabelByLang": {"sv": "Beroendelära"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/303"},
+      "hiddenLabelByLang": {"sv": "Beroendelära"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30310",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30310",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30310",
       "prefLabelByLang": {
         "sv": "Medicinsk etik",
         "en": "Medical Ethics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/303"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/303"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30311",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30311",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30311",
       "prefLabelByLang": {
         "sv": "Folkhälsovetenskap, global hälsa och socialmedicin",
         "en": "Public Health, Global Health and Social Medicine"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/303"},
-      "scopeNoteByLang": {"sv": "Uppdelning av ämne"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/303"},
       "historyNoteByLang": {"sv": "Epidemiologi 30116 (SSIF2025) var tidigare en del av Folkhälsovetenskap, global hälsa, socialmedicin och epidemiologi 30302 (SSIF2011) men utgör numera ett eget ämne."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30312",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30312",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30312",
       "prefLabelByLang": {
         "sv": "Palliativ medicin och palliativ vård",
         "en": "Palliative Medicine and Palliative Care"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/303"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/303"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30313",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30313",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30313",
       "prefLabelByLang": {
         "sv": "Oral hälsa",
         "en": "Oral Health"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/303"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/303"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30314",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30314",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30314",
       "prefLabelByLang": {
         "sv": "Rehabiliteringsmedicin",
         "en": "Rehabilitation Medicine"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/303"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/303"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30399",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30399",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30399",
       "prefLabelByLang": {
         "sv": "Annan hälsovetenskap",
         "en": "Other Health Sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/303"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/303"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/304",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/304",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "304",
       "prefLabelByLang": {
         "sv": "Medicinsk bioteknologi",
         "en": "Medical Biotechnology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/3"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/3"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30401",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30401",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30401",
       "prefLabelByLang": {
         "sv": "Medicinsk bioteknologi",
         "en": "Medical Biotechnology"
       },
-      "commentByLang": {
+      "scopeNoteByLang": {
         "sv": "inriktn. mot cellbiologi (inkl. stamcellsbiologi), molekylärbiologi, mikrobiologi, biokemi eller biofarmaci",
         "en": "Focus on Cell Biology (incl. Stem Cell Biology), Molecular Biology, Microbiology, Biochemistry or Biopharmacy"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/304"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/304"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30402",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30402",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30402",
       "prefLabelByLang": {
         "sv": "Biomedicinsk laboratorievetenskap/teknologi",
         "en": "Biomedical Laboratory Science/Technology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/304"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/304"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30403",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30403",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30403",
       "prefLabelByLang": {
         "sv": "Biomaterialvetenskap",
         "en": "Biomaterials Science"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/304"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/304"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30499",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30499",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30499",
       "prefLabelByLang": {
         "sv": "Annan medicinsk bioteknologi",
         "en": "Other Medical Biotechnology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/304"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/304"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/305",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/305",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "305",
       "prefLabelByLang": {
         "sv": "Annan medicin och hälsovetenskap",
         "en": "Other Medical and Health Sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/3"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/3"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30501",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30501",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30501",
       "prefLabelByLang": {
         "sv": "Rättsmedicin",
         "en": "Forensic Science"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/305"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/305"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30502",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30502",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30502",
       "prefLabelByLang": {
         "sv": "Gerontologi, medicinsk/hälsovetenskaplig inriktning",
         "en": "Gerontology, specialising in Medical and Health Sciences"
       },
-      "commentByLang": {
+      "scopeNoteByLang": {
         "sv": "Samhällsvetenskaplig inriktn.under 50908",
         "en": "Specialising in Social Sciences at 50908"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/305"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/305"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/30599",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/30599",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "30599",
       "prefLabelByLang": {
         "sv": "Övrig annan medicin och hälsovetenskap",
         "en": "Other Medical and Health Sciences not elsewhere specified"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/305"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/305"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/4",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/4",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "4",
       "prefLabelByLang": {
         "sv": "Lantbruksvetenskap och veterinärmedicin",
@@ -3434,572 +3349,558 @@
       }
     },
     {
-      "@id": "https://id.kb.se/term/ssif/401",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/401",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "401",
       "prefLabelByLang": {
         "sv": "Jordbruk, skogsbruk och fiske",
         "en": "Agriculture, Forestry and Fisheries"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/4"},
-      "hiddenLabelByLang": {"sv": "Lantbruksvetenskap, skogsbruk och fiske"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/4"},
+      "hiddenLabelByLang": {"sv": "Lantbruksvetenskap, skogsbruk och fiske"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/40101",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/40101",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "40101",
       "prefLabelByLang": {
         "sv": "Jordbruksvetenskap",
         "en": "Agricultural Science"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/401"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/401"},
       "narrower": [
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "växtgenetik",
             "en": "Plant Genetics"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "växtproduktion"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "jordbruksekologi",
             "en": "Agricultural Ecology"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "genetik"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "agroteknologi",
             "en": "Agricultural Technology"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "förädling"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "agrarhistoria",
             "en": "Agricultural History"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "växtskydd"}
         },
         {
           "@type": "Concept",
-          "prefLabelByLang": {
-            "sv": "",
-            "en": ""
-          }
+          "hiddenLabelByLang": {"sv": "patologi"}
         },
         {
           "@type": "Concept",
-          "prefLabelByLang": {
-            "sv": "",
-            "en": ""
-          }
+          "hiddenLabelByLang": {"sv": "jordbruksekologi"}
         },
         {
           "@type": "Concept",
-          "prefLabelByLang": {
-            "sv": "",
-            "en": ""
-          }
+          "hiddenLabelByLang": {"sv": "agroteknologi"}
         },
         {
           "@type": "Concept",
-          "prefLabelByLang": {
-            "sv": "",
-            "en": ""
-          }
+          "hiddenLabelByLang": {"sv": "agrarhistoria"}
         }
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/40102",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/40102",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "40102",
       "prefLabelByLang": {
         "sv": "Trädgårdsvetenskap/hortikultur",
         "en": "Horticulture"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/401"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/401"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/40103",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/40103",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "40103",
       "prefLabelByLang": {
         "sv": "Livsmedelsvetenskap",
         "en": "Food Science"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/401"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/401"},
       "narrower": [
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "produktkvalitet",
             "en": "Product Quality"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "produktkvalitet"}
         },
         {
           "@type": "Concept",
-          "prefLabelByLang": {
-            "sv": "",
-            "en": ""
-          }
+          "hiddenLabelByLang": {"sv": "vegetabilier"}
         },
         {
           "@type": "Concept",
-          "prefLabelByLang": {
-            "sv": "",
-            "en": ""
-          }
+          "hiddenLabelByLang": {"sv": "mjölk"}
         },
         {
           "@type": "Concept",
-          "prefLabelByLang": {
-            "sv": "",
-            "en": ""
-          }
+          "hiddenLabelByLang": {"sv": "kött"}
         },
         {
           "@type": "Concept",
-          "prefLabelByLang": {
-            "sv": "",
-            "en": ""
-          }
+          "hiddenLabelByLang": {"sv": "fisk"}
         }
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/40104",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/40104",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "40104",
       "prefLabelByLang": {
         "sv": "Skogsvetenskap",
         "en": "Forest Science"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/401"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/401"},
       "narrower": [
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "skogsskötsel",
             "en": "Silviculture"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "inventering"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "skogsgenetik",
             "en": "Forest Genetics"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "planering"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "skogsmykologi",
             "en": "Forest Mycology"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "skötsel"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "skogspatologi",
             "en": "Forest Pathology"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "produktion"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "skogsteknologi",
             "en": "Forest Technology"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "föryngring"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "skogshistoria",
             "en": "Forest History"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "hushållning"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "skogsekologi",
             "en": "Forest Ecology"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "genetik"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "skogsekonomi",
             "en": "Forest Economics"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "mykologi"}
         },
         {
           "@type": "Concept",
-          "prefLabelByLang": {
-            "sv": "",
-            "en": ""
-          }
+          "hiddenLabelByLang": {"sv": "patologi"}
         },
         {
           "@type": "Concept",
-          "prefLabelByLang": {
-            "sv": "",
-            "en": ""
-          }
+          "hiddenLabelByLang": {"sv": "skogsteknologi"}
         },
         {
           "@type": "Concept",
-          "prefLabelByLang": {
-            "sv": "",
-            "en": ""
-          }
+          "hiddenLabelByLang": {"sv": "skogshistoria"}
         }
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/40105",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/40105",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "40105",
       "prefLabelByLang": {
         "sv": "Trävetenskap",
         "en": "Wood Science"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/401"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/401"},
       "narrower": [
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "träteknologi",
             "en": "Wood Technology"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "träteknologi"}
         }
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/40106",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/40106",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "40106",
       "prefLabelByLang": {
         "sv": "Markvetenskap",
         "en": "Soil Science"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/401"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/401"},
       "narrower": [
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "biogeofysik",
             "en": "Biogeophysics"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "biogeofysik"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "biogeokemi",
             "en": "Biogeochemistry"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "biogeokemi"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "markmikrobiologi",
             "en": "Soil Microbiology"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "markmikrobiologi"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "växt-mark interaktioner",
             "en": "Plant-Soil Interactions"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "växt-mark interaktioner"}
         }
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/40107",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/40107",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "40107",
       "prefLabelByLang": {
         "sv": "Fisk- och akvakulturforskning",
         "en": "Fish and Aquacultural Science"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/401"},
-      "scopeNoteByLang": {"sv": "Annan"},
-      "historyNoteByLang": {"sv": "Fiskpopulationsekologi ingick tidigare i Fisk- och akvakulturforskning 40107 (SSIF2011) men ingår nu i Vilt och fiskeförvaltning 40502 (SSIF2025)."},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/401"},
       "narrower": [
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "fiskodling",
             "en": "Fish farming"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "fiskodling"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "fiskgenetik",
             "en": "Fish Genetics"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "genetik"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "fisketologi",
             "en": "Fish Ethology"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "avel"}
         },
         {
           "@type": "Concept",
-          "prefLabelByLang": {
-            "sv": "",
-            "en": ""
-          }
+          "hiddenLabelByLang": {"sv": "fiskpopulationsbiologi"}
         },
         {
           "@type": "Concept",
-          "prefLabelByLang": {
-            "sv": "",
-            "en": ""
-          }
+          "hiddenLabelByLang": {"sv": "fisketologi"}
         }
-      ]
+      ],
+      "historyNoteByLang": {"sv": "Fiskpopulationsekologi ingick tidigare i Fisk- och akvakulturforskning 40107 (SSIF2011) men ingår nu i Vilt och fiskeförvaltning 40502 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/402",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/402",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "402",
       "prefLabelByLang": {
         "sv": "Husdjursvetenskap",
         "en": "Animal and Dairy Science"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/4"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/4"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/40201",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/40201",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "40201",
       "prefLabelByLang": {
         "sv": "Husdjursvetenskap",
         "en": "Animal and Dairy Science"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/402"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/402"},
       "narrower": [
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "djuretik",
             "en": "Animal Ethics"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "utfodring och vård"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "renskötsel",
             "en": "Reindeer Husbandry"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "etologi"}
         },
         {
           "@type": "Concept",
-          "prefLabelByLang": {
-            "sv": "",
-            "en": ""
-          }
+          "hiddenLabelByLang": {"sv": "genetik och avel"}
         },
         {
           "@type": "Concept",
-          "prefLabelByLang": {
-            "sv": "",
-            "en": ""
-          }
+          "hiddenLabelByLang": {"sv": "husdjurshygien"}
         },
         {
           "@type": "Concept",
-          "prefLabelByLang": {
-            "sv": "",
-            "en": ""
-          }
+          "hiddenLabelByLang": {"sv": "nutrition och vård"}
         },
         {
           "@type": "Concept",
-          "prefLabelByLang": {
-            "sv": "",
-            "en": ""
-          }
+          "hiddenLabelByLang": {"sv": "djuretik"}
         }
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/403",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/403",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "403",
       "prefLabelByLang": {
         "sv": "Veterinärmedicin",
         "en": "Veterinary Science"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/4"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/4"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/40301",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/40301",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "40301",
       "prefLabelByLang": {
         "sv": "Medicinsk biovetenskap",
         "en": "Medical Bioscience"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/403"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/403"},
       "narrower": [
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "anatomi",
             "en": "Anatomy"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "anatomi"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "fysiologi",
             "en": "Physiology"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "fysiologi"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "biokemi",
             "en": "Biochemistry"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "biokemi"}
         }
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/40302",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/40302",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "40302",
       "prefLabelByLang": {
         "sv": "Patobiologi",
         "en": "Pathobiology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/403"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/403"},
       "narrower": [
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "immunologi",
             "en": "Immunology"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "immunologi"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "mikrobiologi",
             "en": "Microbiology"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "mikrobiologi"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "patologi",
             "en": "Pathology"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "patologi"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "toxikologi",
             "en": "Toxicology"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "toxikologi"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "farmakologi",
             "en": "Pharmacology"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "farmakologi"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "livsmedelssäkerhet",
             "en": "Food Safety"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "livsmedelssäkerhet"}
         }
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/40303",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/40303",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "40303",
       "prefLabelByLang": {
         "sv": "Klinisk vetenskap",
         "en": "Clinical Science"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/403"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/403"},
       "narrower": [
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "anestesiologi",
             "en": "Anaesthesiology"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "anestesiologi"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "komparativ medicin",
             "en": "Comparative Medicine"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "diagnostik"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "diagnostik",
             "en": "Diagnostics"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "djuromvårdnad"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "djuromvårdnad",
             "en": "Veterinary Nursing"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "epidemiologi"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "epidemiologi",
             "en": "Epidemiology"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "kirurgi"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "kirurgi",
             "en": "Surgery"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "medicin"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "medicin",
             "en": "Medicine"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "reproduktion"}
         },
         {
           "@type": "Concept",
@@ -4011,100 +3912,96 @@
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/40304",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/40304",
+      "@type": "Concept",
       "code": "40304",
-      "hiddenLabelByLang": {"sv": "Annan veterinärmedicin"},
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Annan veterinärmedicin"},
       "isReplacedBy": [
-        {
-          "@id": "https://id.kb.se/term/ssif/40399",
-          "@annotation": {
-            "commentByLang": {"sv": "Ny kod"}
-          }
-        }
+        {"@id": "https://begrepp.uka.se/SSIF/40399"}
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/40399",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/40399",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "40399",
       "prefLabelByLang": {
         "sv": "Annan veterinärmedicin",
         "en": "Other Veterinary Science"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/403"},
-      "scopeNoteByLang": {"sv": "Ny kod"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/403"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/404",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/404",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "404",
       "prefLabelByLang": {
         "sv": "Bioteknologi med applikationer på växter och djur",
         "en": "Agricultural Biotechnology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/4"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/4"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/40401",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/40401",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "40401",
       "prefLabelByLang": {
         "sv": "Växtbioteknologi",
         "en": "Plant Biotechnology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/404"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/404"},
       "narrower": [
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "skogsbioteknologi",
             "en": "Forest Biotechnology"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "skogsbioteknologi"}
         },
         {
           "@type": "Concept",
-          "prefLabelByLang": {
-            "sv": "",
-            "en": ""
-          }
+          "hiddenLabelByLang": {"sv": "genteknologi"}
         }
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/40402",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/40402",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "40402",
       "prefLabelByLang": {
         "sv": "Genetik och förädling inom lantbruksvetenskap",
         "en": "Genetics and Breeding in Agricultural Sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/404"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/404"},
       "narrower": [
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "mikroorganismer",
             "en": "Microorganisms"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "mikroorganismer"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "svampar",
             "en": "Fungi"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "svampar"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "reproduktionsbioteknologi",
             "en": "Reproductive Biotechnology"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "växter och djur inom lantbruksvetenskapsområdet"}
         },
         {
           "@type": "Concept",
@@ -4116,44 +4013,45 @@
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/405",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/405",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "405",
       "prefLabelByLang": {
         "sv": "Annan lantbruksvetenskap",
         "en": "Other Agricultural Sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/4"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/4"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/40501",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/40501",
+      "@type": "Concept",
       "code": "40501",
-      "hiddenLabel": "Förnyelsebar bioenergi",
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Förnyelsebar bioenergi"},
       "isReplacedBy": [
-        {"@id": "https://id.kb.se/term/ssif/20904"}
-      ]
+        {"@id": "https://begrepp.uka.se/SSIF/20904"}
+      ],
+      "historyNoteByLang": {"sv": "Förnyelsebar bioenergi 40501 (SSIF2011) ingår nu i 20904 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/40502",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/40502",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "40502",
       "prefLabelByLang": {
         "sv": "Vilt- och fiskeförvaltning",
         "en": "Fish and Wildlife Management"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/405"},
-      "scopeNoteByLang": {"sv": "Annan"},
-      "historyNoteByLang": {"sv": "Fiskpopulationsekologi ingick tidigare i Fisk- och akvakulturforskning 40107 (SSIF2011) men ingår nu i Vilt och fiskeförvaltning 40502 (SSIF2025)."},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/405"},
       "narrower": [
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "jakt",
             "en": "Hunting"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "jakt"}
         },
         {
           "@type": "Concept",
@@ -4168,148 +4066,135 @@
             "sv": "vilt- och fiskpopulationsekologi",
             "en": "Game and Fishpopulation Ecology"
           }
-        },
-        {
-          "@type": "Concept",
-          "prefLabelByLang": {
-            "sv": "",
-            "en": ""
-          }
         }
-      ]
+      ],
+      "historyNoteByLang": {"sv": "Fiskpopulationsekologi ingick tidigare i Fisk- och akvakulturforskning 40107 (SSIF2011) men ingår nu i Vilt och fiskeförvaltning 40502 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/40504",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/40504",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "40504",
       "prefLabelByLang": {
         "sv": "Miljö- och naturvårdsvetenskap",
         "en": "Environmental Sciences and Nature Conservation"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/405"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/405"},
       "narrower": [
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "biodiversitet",
             "en": "Biodiversity"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "biodiversitet"}
         },
         {
           "@type": "Concept",
-          "prefLabelByLang": {
-            "sv": "",
-            "en": ""
-          }
+          "hiddenLabelByLang": {"sv": "risk"}
         },
         {
           "@type": "Concept",
-          "prefLabelByLang": {
-            "sv": "",
-            "en": ""
-          }
+          "hiddenLabelByLang": {"sv": "Lantbrukets arbetsmiljö och säkerhet"}
         }
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/40503",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/40503",
+      "@type": "Concept",
       "code": "40503",
-      "hiddenLabel": "Lantbrukets arbetsmiljö och säkerhet",
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Lantbrukets arbetsmiljö och säkerhet"},
       "isReplacedBy": [
-        {"@id": "https://id.kb.se/term/ssif/40599"}
-      ]
+        {"@id": "https://begrepp.uka.se/SSIF/40599"}
+      ],
+      "historyNoteByLang": {"sv": "Lantbrukets arbetsmiljö och säkerhet 40503 (SSIF2011) kan exempelvis redovisas i Övrig annan lantbruksvetenskap 40599 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/40108",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/40108",
+      "@type": "Concept",
       "code": "40108",
-      "hiddenLabelByLang": {"sv": "Landskapsarkitektur"},
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Landskapsarkitektur"},
       "isReplacedBy": [
-        {
-          "@id": "https://id.kb.se/term/ssif/40505",
-          "@annotation": {
-            "commentByLang": {"sv": "Bytt forskningsämnesgrupp"}
-          }
-        }
+        {"@id": "https://begrepp.uka.se/SSIF/40505"}
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/40505",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/40505",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "40505",
       "prefLabelByLang": {
         "sv": "Landskapsarkitektur",
         "en": "Landscape Architecture"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/405"},
-      "scopeNoteByLang": {"sv": "Bytt forskningsämnesgrupp"},
-      "historyNoteByLang": {"sv": "Landskapsarkitektur 40505 (SSIF2025) ingick tidigare i Lantbruksvetenskap, skogsbruk och fiske 401 (SSIF2011)."},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/405"},
       "narrower": [
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "planering",
             "en": "Planning"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "planering"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "design",
             "en": "Design"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "design"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "vård",
             "en": "Management"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "vård"}
         }
-      ]
+      ],
+      "historyNoteByLang": {"sv": "Landskapsarkitektur 40505 (SSIF2025) ingick tidigare i Lantbruksvetenskap, skogsbruk och fiske 401 (SSIF2011)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/40506",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/40506",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "40506",
       "prefLabelByLang": {
         "sv": "Jordbruksekonomi och landsbygdsutveckling",
         "en": "Agricultural Economics and Management and Rural development"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/405"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/405"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/40507",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/40507",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "40507",
       "prefLabelByLang": {
         "sv": "Miljöekonomi och förvaltning",
         "en": "Environmental Economics and Management"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/405"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/405"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/40599",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/40599",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "40599",
       "prefLabelByLang": {
         "sv": "Övrig annan lantbruksvetenskap",
         "en": "Other Agricultural Sciences not elsewhere specified"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/405"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/405"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/5",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/5",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "5",
       "prefLabelByLang": {
         "sv": "Samhällsvetenskap",
@@ -4317,434 +4202,428 @@
       }
     },
     {
-      "@id": "https://id.kb.se/term/ssif/501",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/501",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "501",
       "prefLabelByLang": {
         "sv": "Psykologi",
         "en": "Psychology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/5"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/5"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50101",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50101",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50101",
       "prefLabelByLang": {
         "sv": "Psykologi",
         "en": "Psychology"
       },
-      "commentByLang": {
+      "scopeNoteByLang": {
         "sv": "exklusive tillämpad psykologi",
         "en": "Excluding Applied Psychology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/501"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/501"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50102",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50102",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50102",
       "prefLabelByLang": {
         "sv": "Tillämpad psykologi",
         "en": "Applied Psychology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/501"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/501"},
       "narrower": [
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "klinisk psykologi",
             "en": "Clinical Psychology"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "klinisk psykologi"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "psykoterapi",
             "en": "Psychotherapy"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "psykoterapi"}
         }
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/502",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/502",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "502",
       "prefLabelByLang": {
         "sv": "Ekonomi och näringsliv",
         "en": "Economics and Business"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/5"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/5"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50201",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50201",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50201",
       "prefLabelByLang": {
         "sv": "Nationalekonomi",
         "en": "Economics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/502"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/502"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50202",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50202",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50202",
       "prefLabelByLang": {
         "sv": "Företagsekonomi",
         "en": "Business Administration"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/502"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/502"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50203",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50203",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50203",
       "prefLabelByLang": {
         "sv": "Ekonomisk historia",
         "en": "Economic History"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/502"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/502"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/503",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/503",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "503",
       "prefLabelByLang": {
         "sv": "Utbildningsvetenskap",
         "en": "Educational Sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/5"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/5"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50301",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50301",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50301",
       "prefLabelByLang": {
         "sv": "Pedagogik",
         "en": "Pedagogy"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/503"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/503"},
       "narrower": [
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "special- och andra inriktningar av pedagogik",
             "en": "Special Needs- and other orientations of Pedagogy"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "special- och andra inriktningar av pedagogik"}
         }
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50302",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50302",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50302",
       "prefLabelByLang": {
         "sv": "Didaktik",
         "en": "Didactics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/503"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/503"},
       "narrower": [
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "allmän- och  ämnesdidaktik",
             "en": "General and Subject Didactics"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "allmän- och  ämnesdidaktik"}
         }
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50304",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50304",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50304",
       "prefLabelByLang": {
         "sv": "Pedagogiskt arbete",
         "en": "Educational Work"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/503"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/503"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50303",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/50303",
+      "@type": "Concept",
       "code": "50303",
-      "hiddenLabel": "Lärande",
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Lärande"},
       "isReplacedBy": [
-        {"@id": "https://id.kb.se/term/ssif/50301"},
-        {"@id": "https://id.kb.se/term/ssif/50302"},
-        {"@id": "https://id.kb.se/term/ssif/50399"}
-      ]
+        {"@id": "https://begrepp.uka.se/SSIF/50301"},
+        {"@id": "https://begrepp.uka.se/SSIF/50302"},
+        {"@id": "https://begrepp.uka.se/SSIF/50399"}
+      ],
+      "historyNoteByLang": {"sv": "Lärande 50303 (SSIF2011) ingår numera i Pedagogik 50301, Didaktik 50302 eller Annan utbildningsvetenskaplig forskning 50399 (SSIF2025) beroende på forskningen/utbildningens karraktär."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50399",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50399",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50399",
       "prefLabelByLang": {
         "sv": "Annan utbildningsvetenskaplig forskning",
         "en": "Other Educational Sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/503"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/503"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/504",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/504",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "504",
       "prefLabelByLang": {
         "sv": "Sociologi",
         "en": "Sociology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/5"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/5"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50401",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50401",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50401",
       "prefLabelByLang": {
         "sv": "Sociologi",
         "en": "Sociology"
       },
-      "commentByLang": {
+      "scopeNoteByLang": {
         "sv": "exklusive socialt arbete, socialantropologi, demografi och kriminologi",
         "en": "Excluding Social Work, Social Anthropology, Demography and Criminology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/504"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/504"},
       "hiddenLabelByLang": {"sv": "Sociologi (exklusive socialt arbete, socialpsykologi och socialantropologi)"},
-      "scopeNoteByLang": {"sv": "Annan"},
       "historyNoteByLang": {"sv": "Socialpsykologi  50403 (SSIF2011) ingår numera i Sociologi 50401 (SSIF2025). Demografi 50405 (SSIF2025) ingick tidigare i  Sociologi 50401 (SSIF2011) men utgör numera ett eget ämne."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50403",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/50403",
+      "@type": "Concept",
       "code": "50403",
-      "hiddenLabel": "Socialpsykologi",
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Socialpsykologi"},
       "isReplacedBy": [
-        {"@id": "https://id.kb.se/term/ssif/50401"}
-      ]
+        {"@id": "https://begrepp.uka.se/SSIF/50401"}
+      ],
+      "historyNoteByLang": {"sv": "Socialpsykologi 50403 (SSIF2011) ingår nu i Sociologi 50401 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50402",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50402",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50402",
       "prefLabelByLang": {
         "sv": "Socialt arbete",
         "en": "Social Work"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/504"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/504"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50404",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50404",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50404",
       "prefLabelByLang": {
         "sv": "Socialantropologi",
         "en": "Social Anthropology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/504"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/504"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50405",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50405",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50405",
       "prefLabelByLang": {
         "sv": "Demografi",
         "en": "Demography"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/504"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/504"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50502",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/50502",
+      "@type": "Concept",
       "code": "50502",
-      "hiddenLabelByLang": {"sv": "Juridik och samhälle"},
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Juridik och samhälle"},
       "isReplacedBy": [
-        {
-          "@id": "https://id.kb.se/term/ssif/50406",
-          "@annotation": {
-            "commentByLang": {"sv": "Bytt forskningsämnesgrupp, Uppdelning av ämne"}
-          }
-        }
+        {"@id": "https://begrepp.uka.se/SSIF/50503"}
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50406",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50406",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50406",
       "prefLabelByLang": {
         "sv": "Kriminologi",
         "en": "Criminology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/504"},
-      "scopeNoteByLang": {"sv": "Bytt forskningsämnesgrupp, Uppdelning av ämne"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/504"},
       "historyNoteByLang": {"sv": "Kriminologi 50406 (SSIF2025) ingick tidigare i Juridik och samhälle 50502 (SSIF2011) men utgör nu ett eget ämne."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/505",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/505",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "505",
       "prefLabelByLang": {
         "sv": "Juridik",
         "en": "Law"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/5"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/5"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50501",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50501",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50501",
       "prefLabelByLang": {
         "sv": "Juridik",
         "en": "Law"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/505"},
-      "hiddenLabelByLang": {"sv": "Juridik (exklusive juridik och samhälle)"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/505"},
+      "hiddenLabelByLang": {"sv": "Juridik (exklusive juridik och samhälle)"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50503",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50503",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50503",
       "prefLabelByLang": {
         "sv": "Annan rättsvetenskaplig forskning",
         "en": "Other Legal Research"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/505"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/505"},
       "hiddenLabelByLang": {"sv": "Juridik och samhälle"},
-      "scopeNoteByLang": {"sv": "Annan"},
       "historyNoteByLang": {"sv": "Kriminologi 50406 (SSIF2025) ingick tidigare i Juridik och samhälle 50502 (SSIF2011) men utgör nu ett eget ämne. Övrig forskning inom juridik och samhälle 50502 (SSIF2011) ingår numera i Annan rättsvetenskaplig forskning 50503(SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/506",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/506",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "506",
       "prefLabelByLang": {
         "sv": "Statsvetenskap",
         "en": "Political Science"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/5"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/5"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50601",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50601",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50601",
       "prefLabelByLang": {
         "sv": "Statsvetenskap",
         "en": "Political Science"
       },
-      "commentByLang": {
+      "scopeNoteByLang": {
         "sv": "exklusive freds- och konfliktforskning",
         "en": "Excluding Peace and Conflict Studies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/506"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/506"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50901",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/50901",
+      "@type": "Concept",
       "code": "50901",
-      "hiddenLabel": "Tvärvetenskapliga studier inom samhällsvetenskap",
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Tvärvetenskapliga studier inom samhällsvetenskap"},
       "isReplacedBy": [
-        {"@id": "https://id.kb.se/term/ssif/50999"}
+        {"@id": "https://begrepp.uka.se/SSIF/50999"}
       ],
       "related": [
-        {
-          "@id": "https://id.kb.se/term/ssif/50604",
-          "@annotation": {
-            "commentByLang": {"sv": "Uppdelning av ämne, bytt forskningsämnesgrupp"}
-          }
-        }
-      ]
+        {"@id": "https://begrepp.uka.se/SSIF/50604"}
+      ],
+      "historyNoteByLang": {"sv": "Ingår numera i det ämne som ligger närmst forskningen/utbildningen eller Övrig annan samhällsvetenskap 50999."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50604",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50604",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50604",
       "prefLabelByLang": {
         "sv": "Freds- och konfliktforskning",
         "en": "Peace and Conflict Studies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/506"},
-      "scopeNoteByLang": {"sv": "Uppdelning av ämne, bytt forskningsämnesgrupp"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/506"},
       "historyNoteByLang": {"sv": "Freds- och konfliktforskning 50604 (SSIF2025) ingick tidigare i Tvärvetenskapliga studier inom samhällsvetenskap 50901 (SSIF2011) men utgör nu ett eget ämne."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50603",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/50603",
+      "@type": "Concept",
       "code": "50603",
-      "hiddenLabel": "Globaliseringsstudier",
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Globaliseringsstudier"},
       "isReplacedBy": [
-        {"@id": "https://id.kb.se/term/ssif/50703"}
-      ]
+        {"@id": "https://begrepp.uka.se/SSIF/50703"}
+      ],
+      "historyNoteByLang": {"sv": "Ingår numera i Andra geografiska studier 50703 (SSIF2025) eller det ämne som ligger närmast forskningen/utbildningen."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/507",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/507",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "507",
       "prefLabelByLang": {
         "sv": "Social och ekonomisk geografi",
         "en": "Social and Economic Geography"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/5"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/5"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50701",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50701",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50701",
       "prefLabelByLang": {
         "sv": "Kulturgeografi",
         "en": "Human Geography"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/507"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/507"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50702",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50702",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50702",
       "prefLabelByLang": {
         "sv": "Ekonomisk geografi",
         "en": "Economic Geography"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/507"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/507"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50703",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50703",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50703",
       "prefLabelByLang": {
         "sv": "Andra geografiska studier",
         "en": "Other Geographic Studies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/507"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"},
-      "historyNoteByLang": {"sv": "Turism ingick tidigare i Ekonomisk geografi 50702 (SSIF2011) men ingår nu i Andra geografiska studier 50703 (SSIF2025)."},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/507"},
       "narrower": [
         {
           "@type": "Concept",
@@ -4753,65 +4632,66 @@
             "en": "Tourism, Urban, Rural, and Global Studies"
           }
         }
-      ]
+      ],
+      "historyNoteByLang": {"sv": "Turism ingick tidigare i Ekonomisk geografi 50702 (SSIF2011) men ingår nu i Andra geografiska studier 50703 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/508",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/508",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "508",
       "prefLabelByLang": {
         "sv": "Medie-, kommunikations-, och informationsvetenskaper",
         "en": "Media and Communications"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/5"},
-      "hiddenLabelByLang": {"sv": "Medie- och kommunikationsvetenskap"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/5"},
+      "hiddenLabelByLang": {"sv": "Medie- och kommunikationsvetenskap"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50801",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50801",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50801",
       "prefLabelByLang": {
         "sv": "Medie- och kommunikationsvetenskap",
         "en": "Media and Communication Studies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/508"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/508"},
       "hiddenLabelByLang": {"sv": "Medievetenskap"},
-      "scopeNoteByLang": {"sv": "Sammanslagning av ämnen"},
       "historyNoteByLang": {"sv": "Medievetenskap 50801 (SSIF2011) har slagits samman med Kommunikationsvetenskap 50802 (SSIF2011) och utgör tillsammans Medie- och kommunikationsvetenskap 50801 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50802",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/50802",
+      "@type": "Concept",
       "code": "50802",
-      "hiddenLabel": "Kommunikationsvetenskap",
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Kommunikationsvetenskap"},
       "isReplacedBy": [
-        {"@id": "https://id.kb.se/term/ssif/50801"}
-      ]
+        {"@id": "https://begrepp.uka.se/SSIF/50801"}
+      ],
+      "historyNoteByLang": {"sv": "Medievetenskap 50801 (SSIF2011) har slagits samman med Kommunikationsvetenskap 50802 (SSIF2011) och utgör tillsammans Medie- och kommunikationsvetenskap 50801 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50803",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/50803",
+      "@type": "Concept",
       "code": "50803",
-      "hiddenLabel": "Mänsklig interaktion med IKT",
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Mänsklig interaktion med IKT"},
       "isReplacedBy": [
-        {"@id": "https://id.kb.se/term/ssif/50804"}
-      ]
+        {"@id": "https://begrepp.uka.se/SSIF/50804"}
+      ],
+      "historyNoteByLang": {"sv": "Mänsklig interaktion med IKT 50803 (SSIF2011) ingår numera i Systemvetenskap, informationssystem och informatik med samhällsvetenskaplig inriktning 50804 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50804",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50804",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50804",
       "prefLabelByLang": {
         "sv": "Systemvetenskap, informationssystem och informatik med samhällsvetenskaplig inriktning",
         "en": "Information Systems, Social aspects"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/508"},
-      "scopeNoteByLang": {"sv": "Sammanslagning av ämnen"},
-      "historyNoteByLang": {"sv": "Mänsklig interaktion med IKT 50803 (SSIF2011) ingår numera i Systemvetenskap, informationssystem och informatik med samhällsvetenskaplig inriktning 50804 (SSIF2025)."},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/508"},
       "narrower": [
         {
           "@type": "Concept",
@@ -4820,190 +4700,179 @@
             "en": "Human Aspects of ICT"
           }
         }
-      ]
+      ],
+      "historyNoteByLang": {"sv": "Mänsklig interaktion med IKT 50803 (SSIF2011) ingår numera i Systemvetenskap, informationssystem och informatik med samhällsvetenskaplig inriktning 50804 (SSIF2025)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50805",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50805",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50805",
       "prefLabelByLang": {
         "sv": "Biblioteks-och informationsvetenskap",
         "en": "Information Studies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/508"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/508"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/509",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/509",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "509",
       "prefLabelByLang": {
         "sv": "Annan samhällsvetenskap",
         "en": "Other Social Sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/5"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/5"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50902",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50902",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50902",
       "prefLabelByLang": {
         "sv": "Genusstudier",
         "en": "Gender Studies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/509"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/509"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50903",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50903",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50903",
       "prefLabelByLang": {
         "sv": "Arbetslivsstudier",
         "en": "Work Sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/509"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/509"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50904",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50904",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50904",
       "prefLabelByLang": {
         "sv": "Internationell migration och etniska relationer",
         "en": "International Migration and Ethnic Relations"
       },
       "altLabelByLang": {"sv": "IMER"},
-      "broader": {"@id": "https://id.kb.se/term/ssif/509"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/509"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50602",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/50602",
+      "@type": "Concept",
       "code": "50602",
-      "hiddenLabelByLang": {"sv": "Studier av offentlig förvaltning"},
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Studier av offentlig förvaltning"},
       "isReplacedBy": [
-        {
-          "@id": "https://id.kb.se/term/ssif/50905",
-          "@annotation": {
-            "commentByLang": {"sv": "Bytt forskningsämnesgrupp"}
-          }
-        }
+        {"@id": "https://begrepp.uka.se/SSIF/50905"}
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50905",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50905",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50905",
       "prefLabelByLang": {
         "sv": "Studier av offentlig förvaltning",
         "en": "Public Administration Studies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/509"},
-      "scopeNoteByLang": {"sv": "Bytt forskningsämnesgrupp"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/509"},
       "historyNoteByLang": {"sv": "Studier av offentlig förvaltning 50905 (SSIF2025) ingick tidigare i Statsvetenskap 506 (SSIF2011)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50906",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50906",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50906",
       "prefLabelByLang": {
         "sv": "Utvecklingsstudier",
         "en": "Development Studies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/509"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/509"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50907",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50907",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50907",
       "prefLabelByLang": {
         "sv": "Statistik inom samhällsvetenskap",
         "en": "Statistics in Social Sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/509"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/509"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50908",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50908",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50908",
       "prefLabelByLang": {
         "sv": "Samhällsvetenskapliga hälso- och koststudier",
         "en": "Health and Diet Studies in Social Sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/509"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/509"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50909",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50909",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50909",
       "prefLabelByLang": {
         "sv": "Miljövetenskapliga studier inom samhällsvetenskap",
         "en": "Environmental Studies in Social Sciences"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/509"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/509"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50910",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50910",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50910",
       "prefLabelByLang": {
         "sv": "Barn- och ungdomsvetenskap",
         "en": "Child and Youth Studies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/509"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/509"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50911",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50911",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50911",
       "prefLabelByLang": {
         "sv": "Krigs-, kris-, säkerhetsvetenskaper",
         "en": "War, Crisis, and Security Studies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/509"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/509"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50912",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50912",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50912",
       "prefLabelByLang": {
         "sv": "Teknik och samhälle",
         "en": "Science and Technology Studies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/509"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/509"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/50999",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/50999",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "50999",
       "prefLabelByLang": {
         "sv": "Övrig annan samhällsvetenskap",
         "en": "Other Social Sciences not elsewhere specified"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/509"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/509"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/6",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/6",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "6",
       "prefLabelByLang": {
         "sv": "Humaniora och konst",
@@ -5011,339 +4880,331 @@
       }
     },
     {
-      "@id": "https://id.kb.se/term/ssif/601",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/601",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "601",
       "prefLabelByLang": {
         "sv": "Historia och arkeologi",
         "en": "History and Archaeology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/6"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/6"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60101",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60101",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60101",
       "prefLabelByLang": {
         "sv": "Historia",
         "en": "History"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/601"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/601"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60102",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60102",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60102",
       "prefLabelByLang": {
         "sv": "Teknik- och miljöhistoria",
         "en": "Technology and Environmental History"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/601"},
-      "hiddenLabelByLang": {"sv": "Teknikhistoria"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/601"},
+      "hiddenLabelByLang": {"sv": "Teknikhistoria"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60103",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60103",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60103",
       "prefLabelByLang": {
         "sv": "Arkeologi",
         "en": "Archaeology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/601"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/601"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60305",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/60305",
+      "@type": "Concept",
       "code": "60305",
-      "hiddenLabelByLang": {"sv": "Idé- och lärdomshistoria"},
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Idé- och lärdomshistoria"},
       "isReplacedBy": [
-        {
-          "@id": "https://id.kb.se/term/ssif/60104",
-          "@annotation": {
-            "commentByLang": {"sv": "Bytt forskningsämnesgrupp"}
-          }
-        }
+        {"@id": "https://begrepp.uka.se/SSIF/60104"}
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60104",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60104",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60104",
       "prefLabelByLang": {
         "sv": "Idé- och lärdomshistoria",
         "en": "History of Science and Ideas"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/601"},
-      "scopeNoteByLang": {"sv": "Bytt forskningsämnesgrupp"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/601"},
       "historyNoteByLang": {"sv": "Idé- och lärdomshistoria 60104 (SSIF2025) ingick tidigare i Filosofi, etik och religion 603 (SSIF2011)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60501",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/60501",
+      "@type": "Concept",
       "code": "60501",
-      "hiddenLabelByLang": {"sv": "Antikvetenskap"},
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Antikvetenskap"},
       "isReplacedBy": [
-        {
-          "@id": "https://id.kb.se/term/ssif/60105",
-          "@annotation": {
-            "commentByLang": {"sv": "Bytt forskningsämnesgrupp"}
-          }
-        }
+        {"@id": "https://begrepp.uka.se/SSIF/60105"}
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60105",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60105",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60105",
       "prefLabelByLang": {
         "sv": "Antikvetenskap",
         "en": "Classical Archaeology and Ancient History"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/601"},
-      "scopeNoteByLang": {"sv": "Bytt forskningsämnesgrupp"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/601"},
       "historyNoteByLang": {"sv": "Antikvetenskap 60105 (SSIF2025) ingick tidigare i Annan humaniora 605 (SSIF2011)."}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/602",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/602",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "602",
       "prefLabelByLang": {
         "sv": "Språk och litteratur",
         "en": "Languages and Literature"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/6"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/6"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60201",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60201",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60201",
       "prefLabelByLang": {
         "sv": "Jämförande språkvetenskap och allmän lingvistik",
         "en": "Comparative Language Studies and Linguistics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/602"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/602"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60202",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60202",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60202",
       "prefLabelByLang": {
         "sv": "Studier av enskilda språk",
         "en": "Studies of Specific Languages"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/602"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/602"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60203",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60203",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60203",
       "prefLabelByLang": {
         "sv": "Litteraturvetenskap",
         "en": "General Literary studies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/602"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/602"},
       "narrower": [
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "litteraturteori",
             "en": "Literary Theory"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "litteraturteori"}
         }
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60204",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60204",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60204",
       "prefLabelByLang": {
         "sv": "Litteraturstudier",
         "en": "Studies of Specific Literatures"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/602"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/602"},
       "narrower": [
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "litteraturer från särskilda språkområden",
             "en": "Literature from specific Language areas"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "litteraturer från särskilda språkområden"}
         }
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60205",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60205",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60205",
       "prefLabelByLang": {
         "sv": "Filologi",
         "en": "Philology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/602"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/602"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60206",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60206",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60206",
       "prefLabelByLang": {
         "sv": "Översättningsvetenskap",
         "en": "Translation Studies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/602"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/602"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60207",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60207",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60207",
       "prefLabelByLang": {
         "sv": "Retorik",
         "en": "Rhetoric"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/602"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/602"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/603",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/603",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "603",
       "prefLabelByLang": {
         "sv": "Filosofi, etik och religion",
         "en": "Philosophy, Ethics and Religion"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/6"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/6"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60301",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60301",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60301",
       "prefLabelByLang": {
         "sv": "Filosofi",
         "en": "Philosophy"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/603"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/603"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60302",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60302",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60302",
       "prefLabelByLang": {
         "sv": "Etik",
         "en": "Ethics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/603"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/603"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60303",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60303",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60303",
       "prefLabelByLang": {
         "sv": "Religionsvetenskap",
         "en": "Religious Studies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/603"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/603"},
       "narrower": [
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "religionsbeteendevetenskap",
             "en": "Social Sciences of Religions"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "religionsbeteendevetenskap"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "tros- och livsåskådningsvetenskap/systematisk teologi",
             "en": "Studies in Faiths and Ideologies/Systematic Theology"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "tros- och livsåskådningsvetenskap/systematisk teologi"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "bibelvetenskap",
             "en": "Biblical Studies"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "bibelvetenskap"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "kyrkovetenskap",
             "en": "Ecclesiology/ Practical Theology"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "kyrkovetenskap"}
         },
         {
           "@type": "Concept",
           "prefLabelByLang": {
             "sv": "kyrkohistoria",
             "en": "Church History"
-          }
+          },
+          "hiddenLabelByLang": {"sv": "kyrkohistoria"}
         }
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60304",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60304",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60304",
       "prefLabelByLang": {
         "sv": "Religionshistoria",
         "en": "History of Religions"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/603"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/603"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60306",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60306",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60306",
       "prefLabelByLang": {
         "sv": "Estetik",
         "en": "Aesthetics"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/603"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/603"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/604",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/604",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "604",
       "prefLabelByLang": {
         "sv": "Konst",
         "en": "Arts"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/6"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/6"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60407",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60407",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60407",
       "prefLabelByLang": {
         "sv": "Konstvetenskap",
         "en": "Art History"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/604"},
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/604"},
       "narrower": [
         {
           "@type": "Concept",
@@ -5355,274 +5216,243 @@
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60408",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60408",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60408",
       "prefLabelByLang": {
         "sv": "Musikvetenskap",
         "en": "Musicology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/604"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/604"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60409",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60409",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60409",
       "prefLabelByLang": {
         "sv": "Teatervetenskap",
         "en": "Performing Art Studies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/604"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/604"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60410",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60410",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60410",
       "prefLabelByLang": {
         "sv": "Filmvetenskap",
         "en": "Film Studies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/604"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/604"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60411",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60411",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60411",
       "prefLabelByLang": {
         "sv": "Fri Konst",
         "en": "Visual Arts"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/604"},
-      "hiddenLabelByLang": {"sv": "Bildkonst"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/604"},
+      "hiddenLabelByLang": {"sv": "Bildkonst"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60402",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/60402",
+      "@type": "Concept",
       "code": "60402",
-      "hiddenLabelByLang": {"sv": "Musik"},
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Musik"},
       "isReplacedBy": [
-        {
-          "@id": "https://id.kb.se/term/ssif/60412",
-          "@annotation": {
-            "commentByLang": {"sv": "Ny kod"}
-          }
-        }
+        {"@id": "https://begrepp.uka.se/SSIF/60412"}
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60412",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60412",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60412",
       "prefLabelByLang": {
         "sv": "Musik",
         "en": "Music"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/604"},
-      "scopeNoteByLang": {"sv": "Ny kod"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/604"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60403",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/60403",
+      "@type": "Concept",
       "code": "60403",
-      "hiddenLabelByLang": {"sv": "Litterär gestaltning"},
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Litterär gestaltning"},
       "isReplacedBy": [
-        {
-          "@id": "https://id.kb.se/term/ssif/60413",
-          "@annotation": {
-            "commentByLang": {"sv": "Ny kod"}
-          }
-        }
+        {"@id": "https://begrepp.uka.se/SSIF/60413"}
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60413",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60413",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60413",
       "prefLabelByLang": {
         "sv": "Litterär gestaltning",
         "en": "Literary Composition"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/604"},
-      "scopeNoteByLang": {"sv": "Ny kod"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/604"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60404",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/60404",
+      "@type": "Concept",
       "code": "60404",
-      "hiddenLabelByLang": {"sv": "Scenkonst"},
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Scenkonst"},
       "isReplacedBy": [
-        {
-          "@id": "https://id.kb.se/term/ssif/60414",
-          "@annotation": {
-            "commentByLang": {"sv": "Ny kod"}
-          }
-        }
+        {"@id": "https://begrepp.uka.se/SSIF/60414"}
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60414",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60414",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60414",
       "prefLabelByLang": {
         "sv": "Scenkonst",
         "en": "Performing Arts"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/604"},
-      "scopeNoteByLang": {"sv": "Ny kod"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/604"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60405",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/60405",
+      "@type": "Concept",
       "code": "60405",
-      "hiddenLabelByLang": {"sv": "Arkitektur"},
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Arkitektur"},
       "isReplacedBy": [
-        {
-          "@id": "https://id.kb.se/term/ssif/60415",
-          "@annotation": {
-            "commentByLang": {"sv": "Ny kod"}
-          }
-        }
+        {"@id": "https://begrepp.uka.se/SSIF/60415"}
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60415",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60415",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60415",
       "prefLabelByLang": {
         "sv": "Arkitektur",
         "en": "Architecture"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/604"},
-      "scopeNoteByLang": {"sv": "Ny kod"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/604"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60406",
-      "@type": "Classification",
+      "@id": "https://begrepp.uka.se/SSIF/60406",
+      "@type": "Concept",
       "code": "60406",
-      "hiddenLabelByLang": {"sv": "Design"},
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Design"},
       "isReplacedBy": [
-        {
-          "@id": "https://id.kb.se/term/ssif/60416",
-          "@annotation": {
-            "commentByLang": {"sv": "Ny kod"}
-          }
-        }
+        {"@id": "https://begrepp.uka.se/SSIF/60416"}
       ]
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60416",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60416",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60416",
       "prefLabelByLang": {
         "sv": "Design",
         "en": "Design"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/604"},
-      "scopeNoteByLang": {"sv": "Ny kod"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/604"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60417",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60417",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60417",
       "prefLabelByLang": {
         "sv": "Film",
         "en": "Film"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/604"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/604"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60418",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60418",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60418",
       "prefLabelByLang": {
         "sv": "Konsthantverk",
         "en": "Crafts"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/604"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/604"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60419",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60419",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60419",
       "prefLabelByLang": {
         "sv": "Fotografi",
         "en": "Photography"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/604"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/604"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/605",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/605",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "605",
       "prefLabelByLang": {
         "sv": "Annan humaniora och konst",
         "en": "Other Humanities"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/6"},
-      "hiddenLabelByLang": {"sv": "Annan humaniora"},
-      "scopeNoteByLang": {"sv": "Bytt benämning"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/6"},
+      "hiddenLabelByLang": {"sv": "Annan humaniora"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60502",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60502",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60502",
       "prefLabelByLang": {
         "sv": "Kulturstudier",
         "en": "Cultural Studies"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/605"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/605"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60503",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60503",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60503",
       "prefLabelByLang": {
         "sv": "Etnologi",
         "en": "Ethnology"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/605"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/605"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60504",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60504",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60504",
       "prefLabelByLang": {
         "sv": "Tvärdiciplinära studier i humaniora och konst",
         "en": "Interdisciplinary Studies in Humanities and Arts"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/605"},
-      "scopeNoteByLang": {"sv": "Nytt ämne"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/605"}
     },
     {
-      "@id": "https://id.kb.se/term/ssif/60599",
-      "@type": "Classification",
-      "inScheme": {"@id": "https://id.kb.se/term/ssif"},
+      "@id": "https://begrepp.uka.se/SSIF/60599",
+      "@type": "Concept",
+      "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
       "code": "60599",
       "prefLabelByLang": {
         "sv": "Övrig annan humaniora",
         "en": "Other Humanities not elsewhere specified"
       },
-      "broader": {"@id": "https://id.kb.se/term/ssif/605"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/605"}
     }
   ]
 }

--- a/resources/ssif_scheme.xml
+++ b/resources/ssif_scheme.xml
@@ -1,0 +1,1 @@
+<value>https://id.kb.se/term/ssif</value>

--- a/resources/ssif_scheme.xml
+++ b/resources/ssif_scheme.xml
@@ -1,1 +1,1 @@
-<value>https://id.kb.se/term/ssif</value>
+<value>https://begrepp.uka.se/SSIF</value>

--- a/service/swepub.py
+++ b/service/swepub.py
@@ -31,7 +31,7 @@ from tempfile import NamedTemporaryFile
 from simplemma.langdetect import lang_detector
 
 from pipeline.convert import ModsParser
-from pipeline.util import Enrichment, Normalization, Validation, ENRICHING_AUDITORS_CODES
+from pipeline.util import Enrichment, Normalization, Validation, ENRICHING_AUDITORS_CODES, SSIF_SCHEME
 from pipeline.legacy_publication import Publication as LegacyPublication
 from pipeline.ldcache import embellish
 
@@ -466,7 +466,7 @@ def classify():
     else:
         status = "no match"
 
-    suggestions = [dict(embellish({"@id": f"https://id.kb.se/term/ssif/{code}"}, ["broader"]), **{"_score": score}) for code, score in subjects[:5]]
+    suggestions = [dict(embellish({"@id": f"{SSIF_SCHEME}/{code}"}, ["broader"]), **{"_score": score}) for code, score in subjects[:5]]
 
     return {
         "abstract": abstract,

--- a/service/utils/ssif.py
+++ b/service/utils/ssif.py
@@ -1,14 +1,19 @@
 def make_mappings(data):
-    return {
-        term['code']: {
-            'eng': term['prefLabelByLang']['en'],
-            'swe': term['prefLabelByLang']['sv'],
-            'broader': term['broader']['@id'].rsplit('/', 1)[-1]
-            if 'broader' in term
-            else None,
-        }
-        for term in data['@graph']
-    }
+    mappings = {}
+    for term in data['@graph']:
+        if term.get("owl:deprecated", "") == True or term.get("@type", "") != "Concept":
+            continue
+
+        if term.get("prefLabelByLang", {}).get("sv"):
+            mappings[term["code"]] = {
+                "eng": term["prefLabelByLang"]["en"],
+                "swe": term["prefLabelByLang"]["sv"],
+            }
+            if "broader" in term:
+                mappings[term["code"]]["broader"] = term['broader']['@id'].rsplit('/', 1)[-1]
+            else:
+                mappings[term["code"]]["broader"] = None
+    return mappings
 
 
 def build_tree_form(mappings):

--- a/service/vue-client/package.json
+++ b/service/vue-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swepub-vue-client",
-  "version": "2.0.12",
+  "version": "2.1.0",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/service/vue-client/src/assets/json/helpbubbles.json
+++ b/service/vue-client/src/assets/json/helpbubbles.json
@@ -56,7 +56,7 @@
     },
     "validation_flags_SSIF": {
       "title": "SSIF",
-      "text": "Ämnesklassificering enligt Standard för Svensk Indelning av Forskningsämnen (SSIF) ska anges minst på 3-siffernivå (forskningsämnesgrupp)."
+      "text": "Ämnesklassificering enligt Standard för Svensk Indelning av Forskningsämnen (SSIF) ska anges minst på 3-siffernivå (forskningsämnesgrupp) och måste finnas i SSIF 2025."
     },
     "validation_flags_unicode": {
       "title": "Unicode",


### PR DESCRIPTION
Switch to SSIF 2025 classifications. In incoming records, legacy SSIF 2011 classifications are mapped to their replacements or closest alternative, as best as we can. See https://kbse.atlassian.net/browse/SWEPUB2-1135

With this the base URI for classifications is changed from https://id.kb.se/term/ssif to https://begrepp.uka.se/SSIF. If this needs to be changed for whatever reason, it now only has to be changed in one place (`resources/ssif_scheme.xml`).

Related: https://github.com/libris/definitions/pull/466 (source of `resources/ssif.jsonld`)